### PR TITLE
Migrate events, hooks, and rules to QTWorldAccess

### DIFF
--- a/src/main/java/ca/bradj/questown/_vanilla/CheckTreePlantable.java
+++ b/src/main/java/ca/bradj/questown/_vanilla/CheckTreePlantable.java
@@ -44,7 +44,7 @@ public class CheckTreePlantable extends JobPhaseModifier {
         BlockPos above = ctx.blockPos().above();
         Iterable<BlockPos> rg = BlockPos.betweenClosed(above.offset(-1, 0, -1), above.offset(1, 0, 1));
         for (BlockPos pos : rg) {
-            if (!ctx.level().getBlockState(pos).isAir()) {
+            if (!ctx.world().isAir(pos)) {
                 return false;
             }
         }
@@ -81,7 +81,11 @@ public class CheckTreePlantable extends JobPhaseModifier {
             return false;
         }
 
-        ServerLevel level = ctx.level();
+        // TreeFeature.place() is inherently MC-coupled (runs world-gen logic to test
+        // plantability). There is no QTWorldAccess abstraction for this - it intentionally
+        // stays as an asServerLevel() call. During warp, asServerLevel() returns null and
+        // this check is skipped (handled by the null guard above).
+        ServerLevel level = ctx.world().asServerLevel();
         return tree.place(config, new VoidLevel(level), null, level.random, above);
     }
 

--- a/src/main/java/ca/bradj/questown/_vanilla/ChopDownTree.java
+++ b/src/main/java/ca/bradj/questown/_vanilla/ChopDownTree.java
@@ -5,14 +5,12 @@ import ca.bradj.questown.integration.jobs.BeforeExtractEvent;
 import ca.bradj.questown.integration.jobs.BeforeTickEvent;
 import ca.bradj.questown.integration.jobs.JobPhaseModifier;
 import ca.bradj.questown.integration.minecraft.MCHeldItem;
-import ca.bradj.questown.mobs.visitor.ItemAcceptor;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
 
-public class ChopDownTree extends JobPhaseModifier {
+public class ChopDownTree extends JobPhaseModifier implements QTNativeRule {
 
     @Override
     public <CONTEXT> @Nullable CONTEXT beforeExtract(
@@ -21,28 +19,10 @@ public class ChopDownTree extends JobPhaseModifier {
     ) {
         CONTEXT context = super.beforeExtract(ctxInput, event);
         BlockPos treeTrunk = event.workSpot();
-        ServerLevel level = event.level();
-        Block b = level.getBlockState(treeTrunk).getBlock();
-        return removeBlock(context, level, treeTrunk, event.entity(), b);
-    }
-
-    private <CONTEXT> CONTEXT removeBlock(
-            CONTEXT ctxInput,
-            ServerLevel level,
-            BlockPos treeTrunk,
-            ItemAcceptor<CONTEXT> entity,
-            Block block
-    ) {
-        for (BlockPos pos : BlockPos.betweenClosed(treeTrunk.offset(-1, 0, -1), treeTrunk.offset(1, 1, 1))) {
-            BlockState bs = level.getBlockState(pos);
-            if (bs.is(block)) {
-                level.removeBlock(pos, true);
-                MCHeldItem i = MCHeldItem.fromTown(block.asItem());
-                ctxInput = entity.tryGiveItem(ctxInput, i, InventoryFullStrategy.REMOVE_FROM_WORLD);
-                removeBlock(ctxInput, level, pos, entity, bs.getBlock());
-            }
+        for (ItemStack drop : event.world().chopTree(treeTrunk)) {
+            context = event.entity().tryGiveItem(context, MCHeldItem.fromTown(drop), InventoryFullStrategy.REMOVE_FROM_WORLD);
         }
-        return ctxInput;
+        return context;
     }
 
     @Override

--- a/src/main/java/ca/bradj/questown/_vanilla/DeployFishingHookRule.java
+++ b/src/main/java/ca/bradj/questown/_vanilla/DeployFishingHookRule.java
@@ -56,8 +56,15 @@ public class DeployFishingHookRule extends JobPhaseModifier {
             AfterInsertItemEvent<CONTEXT> event
     ) {
         CONTEXT ctx = super.afterInsertItem(ctxInput, event);
-        LivingEntity villager = (LivingEntity) event.level().getEntity(event.inserter());
-        @Nullable FishingHook deployed = deployHere(event.level(), event.workSpot().workPosition(), villager);
+        ServerLevel sl = event.world().asServerLevel();
+        // The FishingHook entity is cosmetic - it does not affect what fish are caught.
+        // During warp and tests, asServerLevel() returns null, so we skip spawning it.
+        // This is intentional: fishing produces correct results without the visual hook.
+        if (sl == null) {
+            return ctx;
+        }
+        LivingEntity villager = (LivingEntity) sl.getEntity(event.inserter());
+        @Nullable FishingHook deployed = deployHere(sl, event.workSpot().workPosition(), villager);
         if (deployed != null) {
             this.hooks.add(deployed);
         }
@@ -70,7 +77,10 @@ public class DeployFishingHookRule extends JobPhaseModifier {
             BeforeExtractEvent<CONTEXT> event
     ) {
         CONTEXT context = super.beforeExtract(ctxInput, event);
-        hooks.forEach(h -> h.remove(Entity.RemovalReason.DISCARDED));
+        if (!hooks.isEmpty()) {
+            hooks.forEach(h -> h.remove(Entity.RemovalReason.DISCARDED));
+            hooks.clear();
+        }
         return context;
     }
 }

--- a/src/main/java/ca/bradj/questown/integration/AssociateItemWithTownSpecialRule.java
+++ b/src/main/java/ca/bradj/questown/integration/AssociateItemWithTownSpecialRule.java
@@ -4,8 +4,9 @@ import ca.bradj.questown.blocks.TownFlagBlock;
 import ca.bradj.questown.integration.jobs.AfterExtractEvent;
 import ca.bradj.questown.integration.jobs.JobPhaseModifier;
 import org.jetbrains.annotations.Nullable;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
 
-public class AssociateItemWithTownSpecialRule extends JobPhaseModifier {
+public class AssociateItemWithTownSpecialRule extends JobPhaseModifier implements QTNativeRule {
 
     @Override
     public <CONTEXT> @Nullable CONTEXT afterExtract(

--- a/src/main/java/ca/bradj/questown/integration/InsertIntoSlotSpecialRule.java
+++ b/src/main/java/ca/bradj/questown/integration/InsertIntoSlotSpecialRule.java
@@ -4,11 +4,11 @@ import ca.bradj.questown.QT;
 import ca.bradj.questown.integration.jobs.AfterInsertItemEvent;
 import ca.bradj.questown.integration.jobs.JobPhaseModifier;
 import ca.bradj.questown.mc.Util;
-import net.minecraft.world.Container;
-import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.core.BlockPos;
 import org.jetbrains.annotations.Nullable;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
 
-public class InsertIntoSlotSpecialRule extends JobPhaseModifier {
+public class InsertIntoSlotSpecialRule extends JobPhaseModifier implements QTNativeRule {
     private final int slotIndex;
 
     public InsertIntoSlotSpecialRule(int i) {
@@ -22,19 +22,14 @@ public class InsertIntoSlotSpecialRule extends JobPhaseModifier {
             AfterInsertItemEvent<CONTEXT> event
     ) {
         CONTEXT context = super.afterInsertItem(ctxInput, event);
-        BlockEntity entity = event.level().getBlockEntity(event.workSpot().workPosition());
-        if (!(entity instanceof Container c)) {
+        BlockPos pos = event.workSpot().workPosition();
+        if (!event.world().insertIntoSlot(pos, slotIndex, event.inserted())) {
             QT.BLOCK_LOGGER.error(
-                    "{}: BlockEntity at {} is not a Container, cannot apply special rule.",
+                    "{}: No container at {}, cannot apply special rule.",
                     getClass(),
-                    Util.getTinyString(event.workSpot().workPosition())
+                    Util.getTinyString(pos)
             );
-            return context;
         }
-
-        // TODO[WARP]: Ensure world containers get filled/emptied after time warp
-        c.setItem(slotIndex, event.inserted());
-
         return context;
     }
 }

--- a/src/main/java/ca/bradj/questown/integration/RandomShortLivedWorkSpot.java
+++ b/src/main/java/ca/bradj/questown/integration/RandomShortLivedWorkSpot.java
@@ -44,7 +44,7 @@ public class RandomShortLivedWorkSpot extends JobPhaseModifier {
     public void beforeTick(BeforeTickEvent bxEvent) {
         super.beforeTick(bxEvent);
         UnsafeVillagerData villagerData = bxEvent.villagerData();
-        ServerLevel serverLevel = bxEvent.level().get();
+        ServerLevel serverLevel = bxEvent.world().get().asServerLevel();
         @Nullable BlockPos override = getOverride(villagerData, false);
         if (override == null) {
             choosePosAndStoreOnVillager(

--- a/src/main/java/ca/bradj/questown/integration/TakeFromSlotSpecialRule.java
+++ b/src/main/java/ca/bradj/questown/integration/TakeFromSlotSpecialRule.java
@@ -6,12 +6,11 @@ import ca.bradj.questown.integration.jobs.BeforeExtractEvent;
 import ca.bradj.questown.integration.jobs.JobPhaseModifier;
 import ca.bradj.questown.integration.minecraft.MCHeldItem;
 import ca.bradj.questown.mc.Util;
-import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.Nullable;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
 
-public class TakeFromSlotSpecialRule extends JobPhaseModifier {
+public class TakeFromSlotSpecialRule extends JobPhaseModifier implements QTNativeRule {
     private final int slotIndex;
 
     public TakeFromSlotSpecialRule(int i) {
@@ -24,17 +23,19 @@ public class TakeFromSlotSpecialRule extends JobPhaseModifier {
             CONTEXT ctxInput,
             BeforeExtractEvent<CONTEXT> event
     ) {
-        BlockEntity entity = event.level().getBlockEntity(event.workSpot());
         CONTEXT ctxBefore = super.beforeExtract(ctxInput, event);
-        if (!(entity instanceof Container c)) {
+        if (ctxBefore == null) {
+            ctxBefore = ctxInput;
+        }
+        ItemStack extracted = event.world().extractFromSlot(event.workSpot(), slotIndex, 1);
+        if (extracted.isEmpty()) {
             QT.BLOCK_LOGGER.error(
-                    "{}: BlockEntity at {} is not a Container, cannot apply special rule.",
+                    "{}: No container or empty slot at {}, cannot apply special rule.",
                     getClass(),
                     Util.getTinyString(event.workSpot())
             );
             return ctxBefore;
         }
-        ItemStack i = c.removeItem(slotIndex, 1);
-        return event.entity().tryGiveItem(ctxBefore, MCHeldItem.fromTown(i), InventoryFullStrategy.DROP_ON_GROUND);
+        return event.entity().tryGiveItem(ctxBefore, MCHeldItem.fromTown(extracted), InventoryFullStrategy.DROP_ON_GROUND);
     }
 }

--- a/src/main/java/ca/bradj/questown/integration/jobs/AfterDropLootEvent.java
+++ b/src/main/java/ca/bradj/questown/integration/jobs/AfterDropLootEvent.java
@@ -1,14 +1,14 @@
 package ca.bradj.questown.integration.jobs;
 
 import ca.bradj.questown.integration.minecraft.MCHeldItem;
+import ca.bradj.questown.world.QTWorldAccess;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
 
 import java.util.function.Consumer;
 
 public record AfterDropLootEvent(
-        ServerLevel level,
+        QTWorldAccess world,
         BlockPos dropSpot,
         ImmutableList<MCHeldItem> itemsBeforeDrop,
         ImmutableList<MCHeldItem> itemsAfterDrop,

--- a/src/main/java/ca/bradj/questown/integration/jobs/AfterExtractEvent.java
+++ b/src/main/java/ca/bradj/questown/integration/jobs/AfterExtractEvent.java
@@ -1,13 +1,13 @@
 package ca.bradj.questown.integration.jobs;
 
+import ca.bradj.questown.world.QTWorldAccess;
 import com.google.common.collect.ImmutableMap;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
 
 import java.util.function.BiFunction;
 
 public record AfterExtractEvent<CONTEXT>(
-        ServerLevel level,
+        QTWorldAccess world,
         BlockPos workSpot,
         BlockPos townFlagPos,
         BiFunction<CONTEXT, ImmutableMap<String, Integer>, CONTEXT> itemDataApplier,

--- a/src/main/java/ca/bradj/questown/integration/jobs/AfterInsertItemEvent.java
+++ b/src/main/java/ca/bradj/questown/integration/jobs/AfterInsertItemEvent.java
@@ -1,15 +1,15 @@
 package ca.bradj.questown.integration.jobs;
 
 import ca.bradj.questown.jobs.WorkedSpot;
+import ca.bradj.questown.world.QTWorldAccess;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
 
 import java.util.UUID;
 import java.util.function.Function;
 
 public record AfterInsertItemEvent<TOWN>(
-        ServerLevel level,
+        QTWorldAccess world,
         ItemStack inserted,
         WorkedSpot<BlockPos> workSpot,
         Function<TOWN, TOWN> bopClearer,

--- a/src/main/java/ca/bradj/questown/integration/jobs/BeforeExtractEvent.java
+++ b/src/main/java/ca/bradj/questown/integration/jobs/BeforeExtractEvent.java
@@ -1,17 +1,19 @@
 package ca.bradj.questown.integration.jobs;
 
 import ca.bradj.questown.mobs.visitor.ItemAcceptor;
+import ca.bradj.questown.world.QTWorldAccess;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.Item;
 
-import java.util.function.BiFunction;
+import java.util.Collection;
+import java.util.function.Supplier;
 
 public record BeforeExtractEvent<TOWN>(
-        ServerLevel level,
+        QTWorldAccess world,
         ItemAcceptor<TOWN> entity,
         BlockPos workSpot,
         Item lastInsertedItem,
-        Runnable poseClearer
+        Runnable poseClearer,
+        Supplier<Collection<BlockPos>> jobBlockPositions
 ) {
 }

--- a/src/main/java/ca/bradj/questown/integration/jobs/BeforeInitEvent.java
+++ b/src/main/java/ca/bradj/questown/integration/jobs/BeforeInitEvent.java
@@ -2,12 +2,12 @@ package ca.bradj.questown.integration.jobs;
 
 import ca.bradj.questown.integration.minecraft.MCHeldItem;
 import ca.bradj.questown.integration.minecraft.MCTownItem;
-import net.minecraft.server.level.ServerLevel;
+import ca.bradj.questown.world.QTWorldAccess;
 
 import java.util.function.Supplier;
 
 public record BeforeInitEvent(
-        Supplier<ServerLevel> level,
+        Supplier<QTWorldAccess> world,
         ItemCheckReplacer<MCHeldItem> replaceIngredients,
         ItemCheckReplacer<MCTownItem> replaceTools,
         JobCheckReplacer jobBlockCheckReplacer,

--- a/src/main/java/ca/bradj/questown/integration/jobs/BeforeTickEvent.java
+++ b/src/main/java/ca/bradj/questown/integration/jobs/BeforeTickEvent.java
@@ -4,11 +4,11 @@ import ca.bradj.questown.integration.minecraft.MCHeldItem;
 import ca.bradj.questown.jobs.WorkLocation;
 import ca.bradj.questown.jobs.production.RoomsNeedingVillagerInput;
 import ca.bradj.questown.town.workstatus.State;
+import ca.bradj.questown.world.QTWorldAccess;
 import ca.bradj.roomrecipes.serialization.MCRoom;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.level.ServerLevel;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Consumer;
@@ -17,7 +17,7 @@ import java.util.function.Supplier;
 
 public record BeforeTickEvent(
         WorkLocation locInfo,
-        Supplier<ServerLevel> level, ImmutableList<MCHeldItem> heldItems,
+        Supplier<QTWorldAccess> world, ImmutableList<MCHeldItem> heldItems,
         Consumer<Function<
                 RoomsNeedingVillagerInput<MCRoom, ResourceLocation, BlockPos>,
                 RoomsNeedingVillagerInput<MCRoom, ResourceLocation, BlockPos>

--- a/src/main/java/ca/bradj/questown/jobs/declarative/PostDropHook.java
+++ b/src/main/java/ca/bradj/questown/jobs/declarative/PostDropHook.java
@@ -5,9 +5,9 @@ import ca.bradj.questown.integration.jobs.AfterDropLootEvent;
 import ca.bradj.questown.integration.jobs.JobPhaseModifier;
 import ca.bradj.questown.integration.minecraft.MCHeldItem;
 import ca.bradj.questown.town.interfaces.TownInterface;
+import ca.bradj.questown.world.QTWorldAccess;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
 
 import java.util.Collection;
 import java.util.function.Consumer;
@@ -19,14 +19,14 @@ public class PostDropHook {
     public static void run(
             TownInterface town,
             Collection<String> rules,
-            ServerLevel level,
+            QTWorldAccess world,
             BlockPos chestPos,
             ImmutableList<MCHeldItem> itemsBeforeDrop,
             ImmutableList<MCHeldItem> itemsAfterDrop,
             Consumer<BlockPos> clearStatus
     ) {
         ImmutableList<JobPhaseModifier> appliers = SpecialRulesRegistry.getRuleAppliers(rules);
-        AfterDropLootEvent bxEvent = new AfterDropLootEvent(level, chestPos, itemsBeforeDrop, itemsAfterDrop, clearStatus);
+        AfterDropLootEvent bxEvent = new AfterDropLootEvent(world, chestPos, itemsBeforeDrop, itemsAfterDrop, clearStatus);
         processMulti(town, appliers, (o, a) -> a.afterDropLoot(o, bxEvent));
     }
 }

--- a/src/main/java/ca/bradj/questown/jobs/declarative/PostExtractHook.java
+++ b/src/main/java/ca/bradj/questown/jobs/declarative/PostExtractHook.java
@@ -3,10 +3,10 @@ package ca.bradj.questown.jobs.declarative;
 import ca.bradj.questown.integration.SpecialRulesRegistry;
 import ca.bradj.questown.integration.jobs.AfterExtractEvent;
 import ca.bradj.questown.integration.jobs.JobPhaseModifier;
+import ca.bradj.questown.world.QTWorldAccess;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
 
 import java.util.Collection;
 import java.util.function.BiFunction;
@@ -19,14 +19,14 @@ public class PostExtractHook {
             TOWN town,
             BlockPos townPos,
             Collection<String> rules,
-            ServerLevel level,
+            QTWorldAccess world,
             BlockPos position,
             BiFunction<TOWN, ImmutableMap<String, Integer>, TOWN> itemDataApplier,
             BiFunction<TOWN, Float, TOWN> hungerUpdater
     ) {
         ImmutableList<JobPhaseModifier> appliers = SpecialRulesRegistry.getRuleAppliers(rules);
         AfterExtractEvent<TOWN> bxEvent = new AfterExtractEvent<>(
-                level, position, townPos, itemDataApplier, hungerUpdater
+                world, position, townPos, itemDataApplier, hungerUpdater
         );
         return processMulti(town, appliers, (o, a) -> a.afterExtract(o, bxEvent));
     }

--- a/src/main/java/ca/bradj/questown/jobs/declarative/PostInsertHook.java
+++ b/src/main/java/ca/bradj/questown/jobs/declarative/PostInsertHook.java
@@ -4,9 +4,9 @@ import ca.bradj.questown.integration.SpecialRulesRegistry;
 import ca.bradj.questown.integration.jobs.AfterInsertItemEvent;
 import ca.bradj.questown.integration.jobs.JobPhaseModifier;
 import ca.bradj.questown.jobs.WorkedSpot;
+import ca.bradj.questown.world.QTWorldAccess;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
 
 import java.util.Collection;
@@ -20,14 +20,14 @@ public class PostInsertHook {
     public static <TOWN> TOWN run(
             TOWN town,
             Collection<String> rules,
-            ServerLevel level,
+            QTWorldAccess world,
             WorkedSpot<BlockPos> position,
             ItemStack item,
             Function<TOWN, TOWN> bopClearer,
             UUID inserter
     ) {
         ImmutableList<JobPhaseModifier> appliers = SpecialRulesRegistry.getRuleAppliers(rules);
-        AfterInsertItemEvent<TOWN> bxEvent = new AfterInsertItemEvent<>(level, item, position, bopClearer, inserter);
+        AfterInsertItemEvent<TOWN> bxEvent = new AfterInsertItemEvent<>(world, item, position, bopClearer, inserter);
         return processMulti(town, appliers, (o, a) -> a.afterInsertItem(o, bxEvent));
     }
 }

--- a/src/main/java/ca/bradj/questown/jobs/declarative/PreExtractHook.java
+++ b/src/main/java/ca/bradj/questown/jobs/declarative/PreExtractHook.java
@@ -6,15 +6,15 @@ import ca.bradj.questown.integration.jobs.BeforeExtractEvent;
 import ca.bradj.questown.integration.jobs.JobPhaseModifier;
 import ca.bradj.questown.integration.minecraft.MCHeldItem;
 import ca.bradj.questown.mobs.visitor.ItemAcceptor;
+import ca.bradj.questown.world.QTWorldAccess;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.Item;
 import org.apache.commons.lang3.function.TriFunction;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
-import java.util.function.BiFunction;
+import java.util.function.Supplier;
 
 import static ca.bradj.questown.jobs.declarative.PrePostHooks.processMulti;
 
@@ -23,11 +23,12 @@ public class PreExtractHook {
     public static <TOWN> TOWN run(
             TOWN town,
             Collection<String> rules,
-            ServerLevel level,
+            QTWorldAccess world,
             TriFunction<TOWN, MCHeldItem, InventoryFullStrategy, TOWN> tryGiveItem,
             BlockPos position,
             Item lastInsertedItem,
-            Runnable clearPoses
+            Runnable clearPoses,
+            Supplier<Collection<BlockPos>> jobBlockPositions
     ) {
         ImmutableList<JobPhaseModifier> appliers = SpecialRulesRegistry.getRuleAppliers(rules);
         ItemAcceptor<TOWN> itemAcceptor = new ItemAcceptor<>() {
@@ -42,7 +43,7 @@ public class PreExtractHook {
             }
         };
         BeforeExtractEvent<TOWN> bxEvent = new BeforeExtractEvent<>(
-                level, itemAcceptor, position, lastInsertedItem, clearPoses
+                world, itemAcceptor, position, lastInsertedItem, clearPoses, jobBlockPositions
         );
         return processMulti(town, appliers, (o, a) -> a.beforeExtract(o, bxEvent));
     }

--- a/src/main/java/ca/bradj/questown/jobs/declarative/PreInitHook.java
+++ b/src/main/java/ca/bradj/questown/jobs/declarative/PreInitHook.java
@@ -4,8 +4,8 @@ import ca.bradj.questown.integration.SpecialRulesRegistry;
 import ca.bradj.questown.integration.jobs.*;
 import ca.bradj.questown.integration.minecraft.MCHeldItem;
 import ca.bradj.questown.integration.minecraft.MCTownItem;
+import ca.bradj.questown.world.QTWorldAccess;
 import com.google.common.collect.ImmutableList;
-import net.minecraft.server.level.ServerLevel;
 
 import java.util.Collection;
 import java.util.function.Supplier;
@@ -16,7 +16,7 @@ public class PreInitHook {
 
     public static void run(
             Collection<String> rules,
-            Supplier<ServerLevel> level,
+            Supplier<QTWorldAccess> world,
             ItemCheckReplacer<MCHeldItem> ingrReplacer,
             ItemCheckReplacer<MCTownItem> toolReplacer,
             JobCheckReplacer jobBlockCheckReplacer,
@@ -24,7 +24,7 @@ public class PreInitHook {
     ) {
         ImmutableList<JobPhaseModifier> appliers = SpecialRulesRegistry.getRuleAppliers(rules);
         BeforeInitEvent bxEvent = new BeforeInitEvent(
-                level,
+                world,
                 ingrReplacer,
                 toolReplacer,
                 jobBlockCheckReplacer,

--- a/src/main/java/ca/bradj/questown/jobs/declarative/PreTickHook.java
+++ b/src/main/java/ca/bradj/questown/jobs/declarative/PreTickHook.java
@@ -8,15 +8,14 @@ import ca.bradj.questown.integration.minecraft.MCHeldItem;
 import ca.bradj.questown.jobs.WorkLocation;
 import ca.bradj.questown.jobs.production.RoomsNeedingVillagerInput;
 import ca.bradj.questown.town.workstatus.State;
+import ca.bradj.questown.world.QTWorldAccess;
 import ca.bradj.roomrecipes.serialization.MCRoom;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.level.ServerLevel;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -27,7 +26,7 @@ public class PreTickHook {
 
     public static void run(
             Collection<String> rules,
-            Supplier<ServerLevel> level,
+            Supplier<QTWorldAccess> world,
             WorkLocation location,
             ImmutableList<MCHeldItem> heldItems,
             Consumer<Function<
@@ -44,7 +43,7 @@ public class PreTickHook {
         ImmutableList<JobPhaseModifier> appliers = SpecialRulesRegistry.getRuleAppliers(rules);
         BeforeTickEvent bxEvent = new BeforeTickEvent(
                 location,
-                level,
+                world,
                 heldItems,
                 roomsReplacer,
                 state,

--- a/src/main/java/ca/bradj/questown/jobs/special/AddItemToContainerSpecialRule.java
+++ b/src/main/java/ca/bradj/questown/jobs/special/AddItemToContainerSpecialRule.java
@@ -3,18 +3,12 @@ package ca.bradj.questown.jobs.special;
 import ca.bradj.questown.QT;
 import ca.bradj.questown.integration.jobs.AfterInsertItemEvent;
 import ca.bradj.questown.integration.jobs.JobPhaseModifier;
-import ca.bradj.questown.mc.Compat;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraftforge.common.capabilities.ForgeCapabilities;
-import net.minecraftforge.common.util.LazyOptional;
-import net.minecraftforge.items.IItemHandler;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Optional;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
 
 public class AddItemToContainerSpecialRule extends
-        JobPhaseModifier {
+        JobPhaseModifier implements QTNativeRule {
 
     public AddItemToContainerSpecialRule() {
 
@@ -27,19 +21,7 @@ public class AddItemToContainerSpecialRule extends
     ) {
         CONTEXT ctxOut = super.afterInsertItem(ctxInput, event);
         BlockPos ws = event.workSpot().workPosition();
-        BlockEntity be = event.level().getBlockEntity(ws);
-        LazyOptional<IItemHandler> cap = be.getCapability(ForgeCapabilities.ITEM_HANDLER);
-        if (cap == null || !cap.isPresent()) {
-            QT.JOB_LOGGER.error("Work spot cannot accept items. " + getClass().getName() + " will not succeed.");
-            return ctxOut;
-        }
-        Optional<IItemHandler> res = cap.resolve();
-        if (res.isEmpty()) {
-            QT.JOB_LOGGER.error("Work spot cannot accept items. " + getClass().getName() + " will not succeed. (2)");
-            return ctxOut;
-        }
-        int amount = 1; // TODO: Implement "stacker"
-        if (!Compat.insertInNextOpenSlot(res.get(), event.inserted(), amount)) {
+        if (!event.world().insertIntoContainer(ws, event.inserted())) {
             QT.JOB_LOGGER.error("Item lost due to not enough space in target container @ {}: {}", ws, event.inserted());
         }
         return ctxOut;

--- a/src/main/java/ca/bradj/questown/jobs/special/ClearBOPSpecialRule.java
+++ b/src/main/java/ca/bradj/questown/jobs/special/ClearBOPSpecialRule.java
@@ -4,9 +4,10 @@ import ca.bradj.questown.core.init.items.ItemsInit;
 import ca.bradj.questown.integration.jobs.AfterInsertItemEvent;
 import ca.bradj.questown.integration.jobs.JobPhaseModifier;
 import org.jetbrains.annotations.Nullable;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
 
 public class ClearBOPSpecialRule extends
-        JobPhaseModifier {
+        JobPhaseModifier implements QTNativeRule {
 
     public ClearBOPSpecialRule() {
 

--- a/src/main/java/ca/bradj/questown/jobs/special/ClearPoseSpecialRule.java
+++ b/src/main/java/ca/bradj/questown/jobs/special/ClearPoseSpecialRule.java
@@ -3,9 +3,10 @@ package ca.bradj.questown.jobs.special;
 import ca.bradj.questown.integration.jobs.BeforeExtractEvent;
 import ca.bradj.questown.integration.jobs.JobPhaseModifier;
 import org.jetbrains.annotations.Nullable;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
 
 public class ClearPoseSpecialRule extends
-        JobPhaseModifier {
+        JobPhaseModifier implements QTNativeRule {
     @Override
     public <X> @Nullable X beforeExtract(
             X context,

--- a/src/main/java/ca/bradj/questown/jobs/special/CompostAtWorkspotSpecialRule.java
+++ b/src/main/java/ca/bradj/questown/jobs/special/CompostAtWorkspotSpecialRule.java
@@ -4,52 +4,46 @@ import ca.bradj.questown.InventoryFullStrategy;
 import ca.bradj.questown.QT;
 import ca.bradj.questown.integration.jobs.*;
 import ca.bradj.questown.integration.minecraft.MCHeldItem;
-import ca.bradj.questown.mc.Compat;
+import ca.bradj.questown.world.QTWorldAccess;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.level.block.ComposterBlock;
-import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.OptionalInt;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
+
 public class CompostAtWorkspotSpecialRule extends
-        JobPhaseModifier {
+        JobPhaseModifier implements QTNativeRule {
     @Override
     public <X> @Nullable X beforeExtract(
             X context,
             BeforeExtractEvent<X> event
     ) {
+        QTWorldAccess world = event.world();
         BlockPos spot = event.workSpot();
-        ServerLevel level = event.level();
 
-        BlockState bs = level.getBlockState(spot);
-
-        if (!(bs.getBlock() instanceof ComposterBlock)) {
+        OptionalInt processingLevel = world.getBlockIntProperty(spot, "level");
+        if (processingLevel.isEmpty()) {
             QT.JOB_LOGGER.error("{} is not a composter. Special rule will fail: {}", spot, getClass().getName());
             return null;
         }
 
-        if (bs.getValue(ComposterBlock.LEVEL) == 8) {
+        OptionalInt maxLevel = world.getMaxBlockIntProperty(spot, "level");
+        if (maxLevel.isPresent() && processingLevel.getAsInt() >= maxLevel.getAsInt()) {
+            world.setBlockIntProperty(spot, "level", 0);
             MCHeldItem toGive = MCHeldItem.fromMCItemStack(Items.BONE_MEAL.getDefaultInstance());
             X out = event.entity().tryGiveItem(context, toGive, InventoryFullStrategy.DROP_ON_GROUND);
-            bs = bs.setValue(ComposterBlock.LEVEL, 0);
-            level.setBlockAndUpdate(spot, bs);
-            Compat.playSound(event.level(), spot, SoundEvents.COMPOSTER_EMPTY, SoundSource.BLOCKS);
+            world.playSound(spot, SoundEvents.COMPOSTER_EMPTY, SoundSource.BLOCKS);
             return out;
         }
 
-        ItemStack stack = event.lastInsertedItem().getDefaultInstance();
-        BlockState blockstate = ComposterBlock.insertItem(bs, level, stack, spot);
-        if (stack.getCount() > 0) {
-            // didn't insert successfully
-            return null;
+        int newLevel = processingLevel.getAsInt() + 1;
+        if (newLevel >= 7) {
+            newLevel = 8;
         }
-
-        level.setBlockAndUpdate(spot, blockstate);
-
+        world.setBlockIntProperty(spot, "level", newLevel);
         return context;
     }
 

--- a/src/main/java/ca/bradj/questown/jobs/special/DestroyBushSpecialRule.java
+++ b/src/main/java/ca/bradj/questown/jobs/special/DestroyBushSpecialRule.java
@@ -5,32 +5,29 @@ import ca.bradj.questown.QT;
 import ca.bradj.questown.integration.jobs.BeforeExtractEvent;
 import ca.bradj.questown.integration.jobs.JobPhaseModifier;
 import ca.bradj.questown.integration.minecraft.MCHeldItem;
-import ca.bradj.questown.mc.Compat;
+import ca.bradj.questown.world.QTWorldAccess;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.BushBlock;
-import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
 
 public class DestroyBushSpecialRule extends
-        JobPhaseModifier {
+        JobPhaseModifier implements QTNativeRule {
     @Override
     public <X> X beforeExtract(
             X context,
             BeforeExtractEvent<X> event
     ) {
-        ServerLevel level = event.level();
+        QTWorldAccess world = event.world();
         BlockPos pos = event.workSpot();
-        BlockState bs = level.getBlockState(pos);
-        if (!(bs.getBlock() instanceof BushBlock)) {
-            QT.JOB_LOGGER.error("Block at {} is not a bush. Special rule failed to apply. [{}]", pos, bs);
+        List<ItemStack> drops = world.getBlockDrops(pos, null);
+        if (drops.isEmpty()) {
+            QT.JOB_LOGGER.error("Block at {} produced no drops. Special rule failed to apply.", pos);
             return null;
         }
-        List<ItemStack> drops = BushBlock.getDrops(bs, level, pos, null);
         X nextContext = context;
         X outContext = null;
         for (ItemStack i : drops) {
@@ -44,8 +41,8 @@ public class DestroyBushSpecialRule extends
                 outContext = o;
             }
         }
-        level.removeBlock(pos, true);
-        Compat.playNeutralSound(level, pos, SoundEvents.GRASS_BREAK);
+        world.removeBlock(pos);
+        world.playSound(pos, SoundEvents.GRASS_BREAK);
         return outContext;
     }
 }

--- a/src/main/java/ca/bradj/questown/jobs/special/FillHungerSpecialRule.java
+++ b/src/main/java/ca/bradj/questown/jobs/special/FillHungerSpecialRule.java
@@ -3,9 +3,10 @@ package ca.bradj.questown.jobs.special;
 import ca.bradj.questown.integration.jobs.AfterExtractEvent;
 import ca.bradj.questown.integration.jobs.JobPhaseModifier;
 import org.jetbrains.annotations.Nullable;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
 
 public class FillHungerSpecialRule extends
-        JobPhaseModifier {
+        JobPhaseModifier implements QTNativeRule {
 
     private final float percent;
 

--- a/src/main/java/ca/bradj/questown/jobs/special/HarvestCropSpecialRule.java
+++ b/src/main/java/ca/bradj/questown/jobs/special/HarvestCropSpecialRule.java
@@ -1,40 +1,32 @@
 package ca.bradj.questown.jobs.special;
 
 import ca.bradj.questown.InventoryFullStrategy;
-import ca.bradj.questown.QT;
 import ca.bradj.questown.integration.jobs.BeforeExtractEvent;
 import ca.bradj.questown.integration.jobs.JobPhaseModifier;
 import ca.bradj.questown.integration.minecraft.MCHeldItem;
-import ca.bradj.questown.mc.Compat;
+import ca.bradj.questown.world.QTWorldAccess;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.CropBlock;
-import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.OptionalInt;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
 
 public class HarvestCropSpecialRule extends
-        JobPhaseModifier {
+        JobPhaseModifier implements QTNativeRule {
     @Override
     public <X> X beforeExtract(
             X context,
             BeforeExtractEvent<X> event
     ) {
-        ServerLevel level = event.level();
-        BlockPos cropBlock = event.workSpot();
-        BlockState bs = level.getBlockState(cropBlock);
-        if (!(bs.getBlock() instanceof CropBlock cb)) {
-            QT.JOB_LOGGER.error("Block at {} is not a crop. Special rule failed to apply. [{}]", cropBlock, bs);
+        QTWorldAccess world = event.world();
+        BlockPos cropPos = findHarvestableCrop(world, event);
+        if (cropPos == null) {
             return null;
         }
-        if (!cb.isMaxAge(bs)) {
-            QT.JOB_LOGGER.error("Crop block at {} is not full age. Special rule failed to apply. [{}]", cropBlock, bs);
-            return null;
-        }
-        List<ItemStack> drops = CropBlock.getDrops(bs, level, cropBlock, null);
+        List<ItemStack> drops = world.getBlockDrops(cropPos, null);
         X nextContext = context;
         X outContext = null;
         for (ItemStack i : drops) {
@@ -48,9 +40,34 @@ public class HarvestCropSpecialRule extends
                 outContext = o;
             }
         }
-        bs = bs.setValue(CropBlock.AGE, 0);
-        level.setBlock(cropBlock, bs, 10);
-        Compat.playNeutralSound(level, cropBlock, SoundEvents.CROP_BREAK);
+        world.setBlockIntProperty(cropPos, "age", 0);
+        world.playSound(cropPos, SoundEvents.CROP_BREAK);
         return outContext;
+    }
+
+    private static <X> @Nullable BlockPos findHarvestableCrop(
+            QTWorldAccess world,
+            BeforeExtractEvent<X> event
+    ) {
+        BlockPos workSpot = event.workSpot();
+        if (isFullyGrown(world, workSpot)) {
+            return workSpot;
+        }
+        List<BlockPos> candidates = world.getShuffledCopy(event.jobBlockPositions().get());
+        for (BlockPos candidate : candidates) {
+            if (isFullyGrown(world, candidate)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isFullyGrown(QTWorldAccess world, BlockPos pos) {
+        OptionalInt stage = world.getBlockIntProperty(pos, "age");
+        if (stage.isEmpty()) {
+            return false;
+        }
+        OptionalInt maxStage = world.getMaxBlockIntProperty(pos, "age");
+        return maxStage.isPresent() && stage.getAsInt() == maxStage.getAsInt();
     }
 }

--- a/src/main/java/ca/bradj/questown/jobs/special/IngredientsFromHeldItemSpecialRule.java
+++ b/src/main/java/ca/bradj/questown/jobs/special/IngredientsFromHeldItemSpecialRule.java
@@ -11,9 +11,10 @@ import net.minecraft.world.item.crafting.Ingredient;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
 
 public class IngredientsFromHeldItemSpecialRule extends
-        JobPhaseModifier {
+        JobPhaseModifier implements QTNativeRule {
 
     private final boolean isTool;
 

--- a/src/main/java/ca/bradj/questown/jobs/special/LieOnWorkspotSpecialRule.java
+++ b/src/main/java/ca/bradj/questown/jobs/special/LieOnWorkspotSpecialRule.java
@@ -3,9 +3,10 @@ package ca.bradj.questown.jobs.special;
 import ca.bradj.questown.integration.jobs.BeforeMoveToNextStateEvent;
 import ca.bradj.questown.integration.jobs.JobPhaseModifier;
 import net.minecraft.world.entity.Pose;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
 
 public class LieOnWorkspotSpecialRule extends
-        JobPhaseModifier {
+        JobPhaseModifier implements QTNativeRule {
     @Override
     public Void beforeMoveToNextState(BeforeMoveToNextStateEvent event) {
         event.requestPose().accept(Pose.SLEEPING);

--- a/src/main/java/ca/bradj/questown/jobs/special/RequireTwoFreeSpotsSpecialRule.java
+++ b/src/main/java/ca/bradj/questown/jobs/special/RequireTwoFreeSpotsSpecialRule.java
@@ -2,24 +2,18 @@ package ca.bradj.questown.jobs.special;
 
 import ca.bradj.questown.integration.jobs.BeforeInitEvent;
 import ca.bradj.questown.integration.jobs.JobPhaseModifier;
-import ca.bradj.questown.mc.Compat;
+import ca.bradj.questown.world.QTWorldAccess;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.ChestBlock;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraftforge.common.util.LazyOptional;
-import net.minecraftforge.items.IItemHandler;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
 
 public class RequireTwoFreeSpotsSpecialRule extends
-        JobPhaseModifier {
+        JobPhaseModifier implements QTNativeRule {
 
     public RequireTwoFreeSpotsSpecialRule() {
 
@@ -29,46 +23,29 @@ public class RequireTwoFreeSpotsSpecialRule extends
     public void beforeInit(BeforeInitEvent bxEvent) {
         super.beforeInit(bxEvent);
         bxEvent.jobBlockCheckReplacer().accept(before -> (ctx) -> {
-            BlockEntity entity = bxEvent.level().get().getBlockEntity(ctx.blockPos());
-            if (entity == null) {
+            QTWorldAccess world = bxEvent.world().get();
+            if (!world.isContainer(ctx.blockPos())) {
                 return false;
             }
-            LazyOptional<IItemHandler> itemHandler = entity.getCapability(Compat.ITEM_HANDLER);
-            if (!itemHandler.isPresent()) {
-                return false;
-            }
-            Optional<IItemHandler> resolve = itemHandler.resolve();
-            if (resolve.isEmpty()) {
-                return false;
-            }
-            IItemHandler handler = resolve.get();
-            if (hasTwoFreeSlots(handler.getSlots(), handler::getStackInSlot)) {
+            int slots = world.getContainerSlotCount(ctx.blockPos());
+            if (hasTwoFreeSlots(slots, i -> world.getContainerSlot(ctx.blockPos(), i))) {
                 return before.test(ctx);
             }
             return false;
         });
         bxEvent.supplyRoomCheckReplacer().accept(before -> (heldItems, room) -> {
             @Nullable BlockPos jBlock = WorkSpotFromHeldItemSpecialRule
-                    .getJobBlockPositionFromHeldItems(heldItems); // TODO: If holding stock request, skip this rule
+                    .getJobBlockPositionFromHeldItems(heldItems);
             for (Map.Entry<BlockPos, Block> b : room.getContainedBlocks().entrySet()) {
                 if (jBlock != null && !jBlock.equals(b.getKey())) {
                     return before.test(heldItems, room);
                 }
-                if (!(b.getValue() instanceof ChestBlock cb)) {
+                QTWorldAccess world = bxEvent.world().get();
+                if (!world.isContainer(b.getKey())) {
                     continue;
                 }
-                ServerLevel serverLevel = bxEvent.level().get();
-                Container cont = ChestBlock.getContainer(
-                        cb,
-                        serverLevel.getBlockState(b.getKey()),
-                        serverLevel,
-                        b.getKey(),
-                        true
-                );
-                if (cont == null) {
-                    continue;
-                }
-                if (hasTwoFreeSlots(cont.getContainerSize(), cont::getItem)) {
+                int slots = world.getContainerSlotCount(b.getKey());
+                if (hasTwoFreeSlots(slots, i -> world.getContainerSlot(b.getKey(), i))) {
                     return before.test(heldItems, room);
                 }
             }

--- a/src/main/java/ca/bradj/questown/jobs/special/SwitchToOrganizerFetcheSpecialRule.java
+++ b/src/main/java/ca/bradj/questown/jobs/special/SwitchToOrganizerFetcheSpecialRule.java
@@ -3,9 +3,10 @@ package ca.bradj.questown.jobs.special;
 import ca.bradj.questown.integration.jobs.BeforeMoveToNextStateEvent;
 import ca.bradj.questown.integration.jobs.JobPhaseModifier;
 import ca.bradj.questown.jobs.JobID;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
 
 public class SwitchToOrganizerFetcheSpecialRule extends
-        JobPhaseModifier {
+        JobPhaseModifier implements QTNativeRule {
 
     @Override
     public Void beforeMoveToNextState(BeforeMoveToNextStateEvent event) {

--- a/src/main/java/ca/bradj/questown/jobs/special/TillWorkspotSpecialRule.java
+++ b/src/main/java/ca/bradj/questown/jobs/special/TillWorkspotSpecialRule.java
@@ -1,32 +1,45 @@
 package ca.bradj.questown.jobs.special;
 
 import ca.bradj.questown.integration.jobs.*;
+import ca.bradj.questown.world.QTToolAction;
+import ca.bradj.questown.world.QTWorldAccess;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.item.Items;
-import net.minecraft.world.item.context.UseOnContext;
-import net.minecraft.world.level.block.FarmBlock;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.common.ToolActions;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
+
 public class TillWorkspotSpecialRule extends
-        JobPhaseModifier {
+        JobPhaseModifier implements QTNativeRule {
     @Override
     public <X> @Nullable X beforeExtract(
             X context,
             BeforeExtractEvent<X> event
     ) {
-        ServerLevel level = event.level();
-        BlockPos groundPos = event.workSpot();
-        BlockState bs = getTilledState(level, groundPos);
-        if (bs == null) return null;
-        level.setBlockAndUpdate(groundPos, bs);
+        QTWorldAccess world = event.world();
+        BlockPos tillable = findTillableBlock(world, event);
+        if (tillable == null) {
+            return null;
+        }
+        world.applyToolTransformation(tillable, QTToolAction.HOE_TILL);
         return context;
+    }
+
+    private static <X> @Nullable BlockPos findTillableBlock(
+            QTWorldAccess world,
+            BeforeExtractEvent<X> event
+    ) {
+        BlockPos workSpot = event.workSpot();
+        if (world.canToolTransformBlock(workSpot, QTToolAction.HOE_TILL)) {
+            return workSpot;
+        }
+        List<BlockPos> candidates = world.getShuffledCopy(event.jobBlockPositions().get());
+        for (BlockPos candidate : candidates) {
+            if (world.canToolTransformBlock(candidate, QTToolAction.HOE_TILL)) {
+                return candidate;
+            }
+        }
+        return null;
     }
 
     @Override
@@ -45,32 +58,5 @@ public class TillWorkspotSpecialRule extends
     @Override
     public void beforeTick(BeforeTickEvent bxEvent) {
 
-    }
-
-
-    @Nullable
-    public static BlockState getTilledState(
-            ServerLevel level,
-            BlockPos groundPos
-    ) {
-        BlockState bs = level.getBlockState(groundPos);
-        BlockHitResult bhr = new BlockHitResult(
-                Vec3.atCenterOf(groundPos), Direction.UP,
-                groundPos, false
-        );
-        bs = bs.getToolModifiedState(new UseOnContext(
-                level, null, InteractionHand.MAIN_HAND,
-                // TODO: Determine tool from held item
-                Items.WOODEN_HOE.getDefaultInstance(), bhr
-        ), ToolActions.HOE_TILL, false);
-
-        if (bs != null) {
-            BlockState moistened = bs.setValue(FarmBlock.MOISTURE, 2);
-            if (!moistened.equals(bs)) {
-                return moistened;
-            }
-        }
-
-        return null;
     }
 }

--- a/src/main/java/ca/bradj/questown/jobs/special/UseLastInsertedItemOnBlockSpecialRule.java
+++ b/src/main/java/ca/bradj/questown/jobs/special/UseLastInsertedItemOnBlockSpecialRule.java
@@ -3,38 +3,27 @@ package ca.bradj.questown.jobs.special;
 import ca.bradj.questown.QT;
 import ca.bradj.questown.integration.jobs.BeforeExtractEvent;
 import ca.bradj.questown.integration.jobs.JobPhaseModifier;
+import ca.bradj.questown.world.QTWorldAccess;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.InteractionResult;
 import net.minecraft.world.item.Item;
-import net.minecraft.world.item.context.UseOnContext;
-import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.world.phys.Vec3;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
 
 public class UseLastInsertedItemOnBlockSpecialRule extends
-        JobPhaseModifier {
+        JobPhaseModifier implements QTNativeRule {
     @Override
     public <X> X beforeExtract(
             X context,
             BeforeExtractEvent<X> event
     ) {
-        BlockPos groundPos = event.workSpot();
-        ServerLevel level = event.level();
-
-        BlockHitResult bhr = new BlockHitResult(
-                Vec3.atCenterOf(groundPos), Direction.UP,
-                groundPos, false
-        );
         Item item = event.lastInsertedItem();
-        InteractionResult result = item.useOn(new UseOnContext(
-                level, null, InteractionHand.MAIN_HAND,
-                item.getDefaultInstance(), bhr
-        ));
-        if (!result.consumesAction()) {
-            String msg = "Failed to use item {} on block at {}";
-            QT.JOB_LOGGER.error(msg, item, groundPos);
+        if (item == null) {
+            return null;
+        }
+        BlockPos groundPos = event.workSpot();
+        QTWorldAccess world = event.world();
+        boolean success = world.useItemOnBlock(item.getDefaultInstance(), groundPos);
+        if (!success) {
+            QT.JOB_LOGGER.error("Failed to use item {} on block at {}", item, groundPos);
         }
         return null;
     }

--- a/src/main/java/ca/bradj/questown/jobs/special/WorkSpotFromHeldItemSpecialRule.java
+++ b/src/main/java/ca/bradj/questown/jobs/special/WorkSpotFromHeldItemSpecialRule.java
@@ -22,9 +22,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
 
 public class WorkSpotFromHeldItemSpecialRule extends
-        JobPhaseModifier {
+        JobPhaseModifier implements QTNativeRule {
 
     @Override
     public void beforeTick(BeforeTickEvent bxEvent) {

--- a/src/test/java/ca/bradj/questown/jobs/special/ContainerRuleTest.java
+++ b/src/test/java/ca/bradj/questown/jobs/special/ContainerRuleTest.java
@@ -1,0 +1,262 @@
+package ca.bradj.questown.jobs.special;
+
+import ca.bradj.questown.InventoryFullStrategy;
+import ca.bradj.questown.integration.InsertIntoSlotSpecialRule;
+import ca.bradj.questown.integration.TakeFromSlotSpecialRule;
+import ca.bradj.questown.integration.jobs.*;
+import ca.bradj.questown.integration.minecraft.MCHeldItem;
+import ca.bradj.questown.jobs.JobBlockTestContext;
+import ca.bradj.questown.jobs.WorkedSpot;
+import ca.bradj.questown.mobs.visitor.ItemAcceptor;
+import ca.bradj.questown.world.TestWorldAccess;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+
+class ContainerRuleTest {
+
+    private static final BlockPos WORK_SPOT = new BlockPos(10, 64, 10);
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    private static class TestItemAcceptor implements ItemAcceptor<Boolean> {
+        final List<MCHeldItem> givenItems = new ArrayList<>();
+
+        @Override
+        public @Nullable Boolean tryGiveItem(
+                Boolean town,
+                MCHeldItem item,
+                InventoryFullStrategy inventoryFullStrategy
+        ) {
+            givenItems.add(item);
+            return town;
+        }
+    }
+
+    // ========== InsertIntoSlotSpecialRule ==========
+
+    @Test
+    void insertIntoSlot_shouldPlaceItemInCorrectSlot() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withContainer(WORK_SPOT, 3);
+
+        ItemStack coal = new ItemStack(Items.COAL, 1);
+        AfterInsertItemEvent<Boolean> event = new AfterInsertItemEvent<>(
+                world,
+                coal,
+                new WorkedSpot<>(WORK_SPOT, 0),
+                town -> town,
+                java.util.UUID.randomUUID()
+        );
+
+        InsertIntoSlotSpecialRule rule = new InsertIntoSlotSpecialRule(1);
+        rule.afterInsertItem(true, event);
+
+        Assertions.assertTrue(
+                ItemStack.matches(coal, world.getSlotContents(WORK_SPOT, 1)),
+                "Item should be in slot 1"
+        );
+        Assertions.assertTrue(
+                world.getSlotContents(WORK_SPOT, 0).isEmpty(),
+                "Slot 0 should remain empty"
+        );
+    }
+
+    @Test
+    void insertIntoSlot_shouldLogError_whenNotAContainer() {
+        TestWorldAccess world = new TestWorldAccess(); // no container
+
+        ItemStack coal = new ItemStack(Items.COAL, 1);
+        AfterInsertItemEvent<Boolean> event = new AfterInsertItemEvent<>(
+                world,
+                coal,
+                new WorkedSpot<>(WORK_SPOT, 0),
+                town -> town,
+                java.util.UUID.randomUUID()
+        );
+
+        InsertIntoSlotSpecialRule rule = new InsertIntoSlotSpecialRule(0);
+        // Should not throw - just logs an error
+        rule.afterInsertItem(true, event);
+    }
+
+    // ========== TakeFromSlotSpecialRule ==========
+
+    @Test
+    void takeFromSlot_shouldExtractItemAndGiveToEntity() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withContainer(WORK_SPOT, 3)
+                .withContainerSlot(WORK_SPOT, 1, new ItemStack(Items.IRON_INGOT, 5));
+
+        TestItemAcceptor entity = new TestItemAcceptor();
+        BeforeExtractEvent<Boolean> event = new BeforeExtractEvent<>(
+                world,
+                entity,
+                WORK_SPOT,
+                Items.IRON_INGOT,
+                () -> {},
+                () -> Collections.singletonList(WORK_SPOT)
+        );
+
+        TakeFromSlotSpecialRule rule = new TakeFromSlotSpecialRule(1);
+        rule.beforeExtract(true, event);
+
+        Assertions.assertEquals(1, entity.givenItems.size(), "Should give 1 item to entity");
+        Assertions.assertEquals(4, world.getSlotContents(WORK_SPOT, 1).getCount(),
+                "Slot should have 4 remaining after extracting 1");
+    }
+
+    @Test
+    void takeFromSlot_shouldReturnContext_whenSlotEmpty() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withContainer(WORK_SPOT, 3);
+
+        TestItemAcceptor entity = new TestItemAcceptor();
+        BeforeExtractEvent<Boolean> event = new BeforeExtractEvent<>(
+                world,
+                entity,
+                WORK_SPOT,
+                Items.IRON_INGOT,
+                () -> {},
+                () -> Collections.singletonList(WORK_SPOT)
+        );
+
+        TakeFromSlotSpecialRule rule = new TakeFromSlotSpecialRule(1);
+        rule.beforeExtract(true, event);
+
+        Assertions.assertTrue(entity.givenItems.isEmpty(), "Should not give any items when slot is empty");
+    }
+
+    // ========== AddItemToContainerSpecialRule ==========
+
+    @Test
+    void addItemToContainer_shouldInsertIntoFirstOpenSlot() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withContainer(WORK_SPOT, 3)
+                .withContainerSlot(WORK_SPOT, 0, new ItemStack(Items.DIAMOND, 1));
+
+        ItemStack wheat = new ItemStack(Items.WHEAT, 1);
+        AfterInsertItemEvent<Boolean> event = new AfterInsertItemEvent<>(
+                world,
+                wheat,
+                new WorkedSpot<>(WORK_SPOT, 0),
+                town -> town,
+                java.util.UUID.randomUUID()
+        );
+
+        AddItemToContainerSpecialRule rule = new AddItemToContainerSpecialRule();
+        rule.afterInsertItem(true, event);
+
+        Assertions.assertTrue(
+                world.getSlotContents(WORK_SPOT, 1).sameItem(wheat),
+                "Item should be in first open slot (slot 1)"
+        );
+    }
+
+    @Test
+    void addItemToContainer_shouldReturnContext_whenContainerFull() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withContainer(WORK_SPOT, 2)
+                .withContainerSlot(WORK_SPOT, 0, new ItemStack(Items.DIAMOND, 1))
+                .withContainerSlot(WORK_SPOT, 1, new ItemStack(Items.COAL, 1));
+
+        ItemStack wheat = new ItemStack(Items.WHEAT, 1);
+        AfterInsertItemEvent<Boolean> event = new AfterInsertItemEvent<>(
+                world,
+                wheat,
+                new WorkedSpot<>(WORK_SPOT, 0),
+                town -> town,
+                java.util.UUID.randomUUID()
+        );
+
+        AddItemToContainerSpecialRule rule = new AddItemToContainerSpecialRule();
+        // Should not throw - just logs an error about lost item
+        rule.afterInsertItem(true, event);
+    }
+
+    // ========== RequireTwoFreeSpotsSpecialRule ==========
+
+    @Test
+    void requireTwoFreeSpots_shouldPassJobBlockCheck_whenTwoSlotsEmpty() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withContainer(WORK_SPOT, 4)
+                .withContainerSlot(WORK_SPOT, 0, new ItemStack(Items.DIAMOND, 1))
+                .withContainerSlot(WORK_SPOT, 1, new ItemStack(Items.COAL, 1));
+
+        Predicate<JobBlockTestContext> captured = runJobBlockCheck(world);
+
+        JobBlockTestContext ctx = new JobBlockTestContext(
+                world, null, WORK_SPOT,
+                Collections::emptyList, Collections::emptyList,
+                false, false
+        );
+
+        Assertions.assertTrue(captured.test(ctx), "Should pass when 2 slots are empty");
+    }
+
+    @Test
+    void requireTwoFreeSpots_shouldFailJobBlockCheck_whenOnlyOneSlotEmpty() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withContainer(WORK_SPOT, 3)
+                .withContainerSlot(WORK_SPOT, 0, new ItemStack(Items.DIAMOND, 1))
+                .withContainerSlot(WORK_SPOT, 1, new ItemStack(Items.COAL, 1));
+
+        Predicate<JobBlockTestContext> captured = runJobBlockCheck(world);
+
+        JobBlockTestContext ctx = new JobBlockTestContext(
+                world, null, WORK_SPOT,
+                Collections::emptyList, Collections::emptyList,
+                false, false
+        );
+
+        Assertions.assertFalse(captured.test(ctx), "Should fail when only 1 slot is empty");
+    }
+
+    @Test
+    void requireTwoFreeSpots_shouldFailJobBlockCheck_whenNotAContainer() {
+        TestWorldAccess world = new TestWorldAccess();
+
+        Predicate<JobBlockTestContext> captured = runJobBlockCheck(world);
+
+        JobBlockTestContext ctx = new JobBlockTestContext(
+                world, null, WORK_SPOT,
+                Collections::emptyList, Collections::emptyList,
+                false, false
+        );
+
+        Assertions.assertFalse(captured.test(ctx), "Should fail when not a container");
+    }
+
+    private static Predicate<JobBlockTestContext> runJobBlockCheck(TestWorldAccess world) {
+        JobCheckReplacer jobCheckReplacer = new JobCheckReplacer(ctx -> true);
+        SupplyRoomCheckReplacer supplyRoomCheckReplacer = new SupplyRoomCheckReplacer();
+
+        BeforeInitEvent event = new BeforeInitEvent(
+                () -> world,
+                ItemCheckReplacer.doNotReplace(),
+                ItemCheckReplacer.doNotReplace(),
+                jobCheckReplacer,
+                supplyRoomCheckReplacer
+        );
+
+        RequireTwoFreeSpotsSpecialRule rule = new RequireTwoFreeSpotsSpecialRule();
+        rule.beforeInit(event);
+
+        return ctx -> JobCheckReplacer.withContext(jobCheckReplacer, ctx).test(ctx.blockPos());
+    }
+}

--- a/src/test/java/ca/bradj/questown/jobs/special/FarmerRuleTest.java
+++ b/src/test/java/ca/bradj/questown/jobs/special/FarmerRuleTest.java
@@ -1,0 +1,321 @@
+package ca.bradj.questown.jobs.special;
+
+import ca.bradj.questown.InventoryFullStrategy;
+import ca.bradj.questown.integration.jobs.BeforeExtractEvent;
+import ca.bradj.questown.integration.minecraft.MCHeldItem;
+import ca.bradj.questown.mobs.visitor.ItemAcceptor;
+import ca.bradj.questown.world.TestWorldAccess;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+class FarmerRuleTest {
+
+    private static final BlockPos WORK_SPOT = new BlockPos(10, 64, 10);
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    /**
+     * Simple ItemAcceptor that tracks items given and always returns the context.
+     */
+    private static class TestItemAcceptor implements ItemAcceptor<Boolean> {
+        final List<MCHeldItem> givenItems = new ArrayList<>();
+
+        @Override
+        public @Nullable Boolean tryGiveItem(
+                Boolean town,
+                MCHeldItem item,
+                InventoryFullStrategy inventoryFullStrategy
+        ) {
+            givenItems.add(item);
+            return town;
+        }
+    }
+
+    private static BeforeExtractEvent<Boolean> makeEvent(
+            TestWorldAccess world,
+            TestItemAcceptor entity
+    ) {
+        return new BeforeExtractEvent<>(
+                world,
+                entity,
+                WORK_SPOT,
+                Items.WHEAT_SEEDS,
+                () -> {},
+                () -> java.util.Collections.singletonList(WORK_SPOT)
+        );
+    }
+
+    private static BeforeExtractEvent<Boolean> makeEvent(
+            TestWorldAccess world,
+            TestItemAcceptor entity,
+            net.minecraft.world.item.Item lastInsertedItem
+    ) {
+        return new BeforeExtractEvent<>(
+                world,
+                entity,
+                WORK_SPOT,
+                lastInsertedItem,
+                () -> {},
+                () -> java.util.Collections.singletonList(WORK_SPOT)
+        );
+    }
+
+    private static BeforeExtractEvent<Boolean> makeEvent(
+            TestWorldAccess world,
+            TestItemAcceptor entity,
+            Collection<BlockPos> jobBlockPositions
+    ) {
+        return new BeforeExtractEvent<>(
+                world,
+                entity,
+                WORK_SPOT,
+                Items.WHEAT_SEEDS,
+                () -> {},
+                () -> jobBlockPositions
+        );
+    }
+
+    // ========== HarvestCropSpecialRule ==========
+
+    @Test
+    void harvestCrop_shouldReturnDrops_whenCropIsFullAge() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withBlockProperty(WORK_SPOT, "age", 7, 7)
+                .withDrops(WORK_SPOT, List.of(new ItemStack(Items.WHEAT, 1)));
+
+        TestItemAcceptor entity = new TestItemAcceptor();
+        BeforeExtractEvent<Boolean> event = makeEvent(world, entity);
+
+        HarvestCropSpecialRule rule = new HarvestCropSpecialRule();
+        Boolean result = rule.beforeExtract(true, event);
+
+        Assertions.assertNotNull(result, "Should return context when crop is full age");
+        Assertions.assertEquals(1, entity.givenItems.size(), "Should give 1 item");
+        Assertions.assertEquals(0, world.getPropertyValue(WORK_SPOT, "age"), "Age should be reset to 0");
+        Assertions.assertEquals(1, world.getSoundsPlayed().size(), "Should play crop break sound");
+    }
+
+    @Test
+    void harvestCrop_shouldReturnNull_whenBlockHasNoAgeProperty() {
+        TestWorldAccess world = new TestWorldAccess();
+
+        TestItemAcceptor entity = new TestItemAcceptor();
+        BeforeExtractEvent<Boolean> event = makeEvent(world, entity);
+
+        HarvestCropSpecialRule rule = new HarvestCropSpecialRule();
+        Boolean result = rule.beforeExtract(true, event);
+
+        Assertions.assertNull(result, "Should return null when block has no age property");
+        Assertions.assertTrue(entity.givenItems.isEmpty(), "Should not give any items");
+    }
+
+    @Test
+    void harvestCrop_shouldReturnNull_whenCropNotFullAge() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withBlockProperty(WORK_SPOT, "age", 3, 7);
+
+        TestItemAcceptor entity = new TestItemAcceptor();
+        BeforeExtractEvent<Boolean> event = makeEvent(world, entity);
+
+        HarvestCropSpecialRule rule = new HarvestCropSpecialRule();
+        Boolean result = rule.beforeExtract(true, event);
+
+        Assertions.assertNull(result, "Should return null when crop is not full age");
+    }
+
+    @Test
+    void harvestCrop_shouldFallBackToJobBlockPositions_whenWorkSpotNotReady() {
+        BlockPos otherCrop = new BlockPos(20, 64, 20);
+        TestWorldAccess world = new TestWorldAccess()
+                .withBlockProperty(WORK_SPOT, "age", 3, 7)
+                .withBlockProperty(otherCrop, "age", 7, 7)
+                .withDrops(otherCrop, List.of(new ItemStack(Items.WHEAT, 1)));
+
+        TestItemAcceptor entity = new TestItemAcceptor();
+        BeforeExtractEvent<Boolean> event = makeEvent(world, entity, List.of(WORK_SPOT, otherCrop));
+
+        HarvestCropSpecialRule rule = new HarvestCropSpecialRule();
+        Boolean result = rule.beforeExtract(true, event);
+
+        Assertions.assertNotNull(result, "Should harvest from fallback position");
+        Assertions.assertEquals(1, entity.givenItems.size(), "Should give 1 item");
+        Assertions.assertEquals(0, world.getPropertyValue(otherCrop, "age"), "Fallback crop age should be reset to 0");
+        Assertions.assertEquals(3, world.getPropertyValue(WORK_SPOT, "age"), "Work spot crop should be unchanged");
+    }
+
+    // ========== DestroyBushSpecialRule ==========
+
+    @Test
+    void destroyBush_shouldGiveDropsAndRemoveBlock() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withDrops(WORK_SPOT, List.of(new ItemStack(Items.SWEET_BERRIES, 3)));
+
+        TestItemAcceptor entity = new TestItemAcceptor();
+        BeforeExtractEvent<Boolean> event = makeEvent(world, entity);
+
+        DestroyBushSpecialRule rule = new DestroyBushSpecialRule();
+        Boolean result = rule.beforeExtract(true, event);
+
+        Assertions.assertNotNull(result, "Should return context when bush has drops");
+        Assertions.assertEquals(1, entity.givenItems.size(), "Should give items");
+        Assertions.assertTrue(world.wasBlockRemoved(WORK_SPOT), "Block should be removed");
+        Assertions.assertEquals(1, world.getSoundsPlayed().size(), "Should play grass break sound");
+    }
+
+    @Test
+    void destroyBush_shouldReturnNull_whenNoDrops() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withDrops(WORK_SPOT, Collections.emptyList());
+
+        TestItemAcceptor entity = new TestItemAcceptor();
+        BeforeExtractEvent<Boolean> event = makeEvent(world, entity);
+
+        DestroyBushSpecialRule rule = new DestroyBushSpecialRule();
+        Boolean result = rule.beforeExtract(true, event);
+
+        Assertions.assertNull(result, "Should return null when no drops");
+        Assertions.assertFalse(world.wasBlockRemoved(WORK_SPOT), "Block should not be removed");
+    }
+
+    // ========== TillWorkspotSpecialRule ==========
+
+    @Test
+    void tillWorkspot_shouldApplyTransformation_whenBlockCanBeTransformed() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withToolTransformResult(WORK_SPOT, true);
+
+        TestItemAcceptor entity = new TestItemAcceptor();
+        BeforeExtractEvent<Boolean> event = makeEvent(world, entity);
+
+        TillWorkspotSpecialRule rule = new TillWorkspotSpecialRule();
+        Boolean result = rule.beforeExtract(true, event);
+
+        Assertions.assertNotNull(result, "Should return context when block can be transformed");
+        Assertions.assertTrue(world.wasTransformApplied(WORK_SPOT), "Transformation should be applied");
+    }
+
+    @Test
+    void tillWorkspot_shouldReturnNull_whenBlockCannotBeTransformed() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withToolTransformResult(WORK_SPOT, false);
+
+        TestItemAcceptor entity = new TestItemAcceptor();
+        BeforeExtractEvent<Boolean> event = makeEvent(world, entity);
+
+        TillWorkspotSpecialRule rule = new TillWorkspotSpecialRule();
+        Boolean result = rule.beforeExtract(true, event);
+
+        Assertions.assertNull(result, "Should return null when block cannot be transformed");
+        Assertions.assertFalse(world.wasTransformApplied(WORK_SPOT), "Transformation should not be applied");
+    }
+
+    // ========== UseLastInsertedItemOnBlockSpecialRule ==========
+
+    @Test
+    void useItemOnBlock_shouldCallUseItem_whenSuccessful() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withUseItemResult(WORK_SPOT, true);
+
+        TestItemAcceptor entity = new TestItemAcceptor();
+        BeforeExtractEvent<Boolean> event = makeEvent(world, entity, Items.WHEAT_SEEDS);
+
+        UseLastInsertedItemOnBlockSpecialRule rule = new UseLastInsertedItemOnBlockSpecialRule();
+        Boolean result = rule.beforeExtract(true, event);
+
+        Assertions.assertNull(result, "Rule always returns null regardless of success");
+        Assertions.assertTrue(world.wasItemUsedOnBlock(WORK_SPOT), "useItemOnBlock should have been called");
+    }
+
+    @Test
+    void useItemOnBlock_shouldCallUseItem_whenFailed() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withUseItemResult(WORK_SPOT, false);
+
+        TestItemAcceptor entity = new TestItemAcceptor();
+        BeforeExtractEvent<Boolean> event = makeEvent(world, entity, Items.WHEAT_SEEDS);
+
+        UseLastInsertedItemOnBlockSpecialRule rule = new UseLastInsertedItemOnBlockSpecialRule();
+        Boolean result = rule.beforeExtract(true, event);
+
+        Assertions.assertNull(result, "Rule always returns null regardless of failure");
+        Assertions.assertTrue(world.wasItemUsedOnBlock(WORK_SPOT), "useItemOnBlock should have been called even on failure");
+    }
+
+    // ========== CompostAtWorkspotSpecialRule ==========
+
+    @Test
+    void compost_shouldExtractProduct_whenFull() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withBlockProperty(WORK_SPOT, "level", 8, 8);
+
+        TestItemAcceptor entity = new TestItemAcceptor();
+        BeforeExtractEvent<Boolean> event = makeEvent(world, entity, Items.WHEAT_SEEDS);
+
+        CompostAtWorkspotSpecialRule rule = new CompostAtWorkspotSpecialRule();
+        Boolean result = rule.beforeExtract(true, event);
+
+        Assertions.assertNotNull(result, "Should return context when product extracted");
+        Assertions.assertEquals(1, entity.givenItems.size(), "Should give compost product");
+        Assertions.assertEquals(0, world.getPropertyValue(WORK_SPOT, "level"), "Level should be reset to 0");
+        Assertions.assertEquals(1, world.getSoundsPlayed().size(), "Should play composter empty sound");
+    }
+
+    @Test
+    void compost_shouldInsertItem_whenNotFull() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withBlockProperty(WORK_SPOT, "level", 3, 8);
+
+        TestItemAcceptor entity = new TestItemAcceptor();
+        BeforeExtractEvent<Boolean> event = makeEvent(world, entity, Items.WHEAT_SEEDS);
+
+        CompostAtWorkspotSpecialRule rule = new CompostAtWorkspotSpecialRule();
+        Boolean result = rule.beforeExtract(true, event);
+
+        Assertions.assertNotNull(result, "Should return context when compost item inserted");
+        Assertions.assertEquals(4, world.getPropertyValue(WORK_SPOT, "level"), "Level should be incremented");
+    }
+
+    @Test
+    void compost_shouldSkipLevel7_whenAtLevel6() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withBlockProperty(WORK_SPOT, "level", 6, 8);
+
+        TestItemAcceptor entity = new TestItemAcceptor();
+        BeforeExtractEvent<Boolean> event = makeEvent(world, entity, Items.WHEAT_SEEDS);
+
+        CompostAtWorkspotSpecialRule rule = new CompostAtWorkspotSpecialRule();
+        Boolean result = rule.beforeExtract(true, event);
+
+        Assertions.assertNotNull(result, "Should return context when compost item inserted");
+        Assertions.assertEquals(8, world.getPropertyValue(WORK_SPOT, "level"), "Level should skip 7 and jump to 8");
+    }
+
+    @Test
+    void compost_shouldReturnNull_whenNoLevelProperty() {
+        TestWorldAccess world = new TestWorldAccess();
+
+        TestItemAcceptor entity = new TestItemAcceptor();
+        BeforeExtractEvent<Boolean> event = makeEvent(world, entity, Items.WHEAT_SEEDS);
+
+        CompostAtWorkspotSpecialRule rule = new CompostAtWorkspotSpecialRule();
+        Boolean result = rule.beforeExtract(true, event);
+
+        Assertions.assertNull(result, "Should return null when block has no level property");
+    }
+}


### PR DESCRIPTION
- Event records: ServerLevel level -> QTWorldAccess world
- BeforeExtractEvent gains jobBlockPositions supplier
- Hook classes accept QTWorldAccess instead of ServerLevel
- Special rules migrated to Tier 1 (QTNativeRule)
- Tier 2 (escape hatch): CheckTreePlantable, DeployFishingHookRule
- Tests: FarmerRuleTest, ContainerRuleTest