### PR TITLE
Warp system rewrite

### DIFF
--- a/src/main/java/ca/bradj/questown/commands/LogDataCommand.java
+++ b/src/main/java/ca/bradj/questown/commands/LogDataCommand.java
@@ -33,7 +33,8 @@ public class LogDataCommand {
                         .then(posArg
                         .executes(css -> run(
                             css.getSource(),
-                            BlockPosArgument.getLoadedBlockPos(css, "pos")
+                            BlockPosArgument.getLoadedBlockPos(css, "pos"),
+                            true
                         )))
                 )
             )
@@ -42,9 +43,10 @@ public class LogDataCommand {
     }
 
 
-    private static int run(
+    static int run(
             CommandSourceStack source,
-            BlockPos target
+            BlockPos target,
+            boolean includeEconomicsData
     ) {
         @Nullable TownFlagBlockEntity tfbe = QTCommands.getFlagOrBroadcast(source, target);
         if (tfbe == null) {
@@ -52,7 +54,7 @@ public class LogDataCommand {
         }
 
         CompoundTag tTag = new CompoundTag();
-        tfbe.writeTownData(tTag);
+        tfbe.writeTownData(tTag, includeEconomicsData);
 
         TownFlagBlockEntity.logStoredData(tfbe, tTag);
 

--- a/src/main/java/ca/bradj/questown/commands/TimeWarpCommand.java
+++ b/src/main/java/ca/bradj/questown/commands/TimeWarpCommand.java
@@ -1,9 +1,11 @@
 package ca.bradj.questown.commands;
 
+import ca.bradj.questown.QT;
+import ca.bradj.questown.integration.minecraft.MCTownState;
+import ca.bradj.questown.town.WarpDebugLog;
 import ca.bradj.questown.town.entity.TownFlagBlockEntity;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
-import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -23,20 +25,28 @@ public class TimeWarpCommand {
                 IntegerArgumentType.integer()
         );
 
-        LiteralArgumentBuilder<CommandSourceStack> subCmd = Commands.literal("warp");
-
         // @formatter:off
         src.register(
             Commands.literal("qt").then(
-                subCmd
-                    .requires(AddExperienceCommand::isCreative)
-                    .then(posArg
-                    .then(amtArg
-                    .executes(css -> run(
-                        css.getSource(),
-                        BlockPosArgument.getLoadedBlockPos(css, "pos"),
-                            IntegerArgumentType.getInteger(css, "ticks")
-                    )))
+                Commands.literal("debug").then(
+                    Commands.literal("warp")
+                        .requires(AddExperienceCommand::isCreative)
+                        .then(posArg
+                        .then(amtArg
+                        .executes(css -> run(
+                            css.getSource(),
+                            BlockPosArgument.getLoadedBlockPos(css, "pos"),
+                            IntegerArgumentType.getInteger(css, "ticks"),
+                            false
+                        ))
+                        .then(Commands.literal("verbose")
+                        .executes(css -> run(
+                            css.getSource(),
+                            BlockPosArgument.getLoadedBlockPos(css, "pos"),
+                            IntegerArgumentType.getInteger(css, "ticks"),
+                            true
+                        )))
+                    ))
                 )
             )
         );
@@ -46,15 +56,63 @@ public class TimeWarpCommand {
     private static int run(
             CommandSourceStack source,
             BlockPos target,
-            Integer ticks
+            Integer ticks,
+            boolean verbose
     ) {
         BlockEntity e = source.getLevel().getBlockEntity(target);
         if (!(e instanceof TownFlagBlockEntity tfbe)) {
-            // TODO: Better error handling?h
             return -1;
         }
 
-        tfbe.warpTime(ticks);
+        LogDataCommand.run(source, target, false);
+
+        WarpDebugLog debugLog = verbose ? beginVerboseLogging(tfbe) : null;
+
+        MCTownState afterState = tfbe.warpTime(ticks);
+
+        if (debugLog != null) {
+            endVerboseLogging(tfbe, debugLog, afterState);
+        }
+
         return 0;
+    }
+
+    private static WarpDebugLog beginVerboseLogging(TownFlagBlockEntity tfbe) {
+        tfbe.toggleDebugLog(DebugLogArgument.TIME_WARP);
+        tfbe.toggleDebugLog(DebugLogArgument.TIME_WARP_DETAIL);
+        tfbe.toggleDebugLog(DebugLogArgument.TIME_WARP_ITEMS);
+        QT.FLAG_LOGGER.info("Verbose warp logging enabled");
+
+        WarpDebugLog debugLog = WarpDebugLog.start();
+        MCTownState beforeState = tfbe.captureCurrentState();
+        if (beforeState != null) {
+            debugLog.captureBeforeState(beforeState);
+            QT.FLAG_LOGGER.info("=== BEFORE WARP ===");
+            QT.FLAG_LOGGER.info("Containers:\n{}", WarpDebugLog.formatAllContainers(beforeState.containers));
+        }
+        return debugLog;
+    }
+
+    private static void endVerboseLogging(
+            TownFlagBlockEntity tfbe,
+            WarpDebugLog debugLog,
+            @Nullable MCTownState afterState
+    ) {
+        QT.FLAG_LOGGER.info("=== WARP EVENTS ===");
+        QT.FLAG_LOGGER.info("{}", debugLog.formatEvents());
+
+        if (afterState != null) {
+            QT.FLAG_LOGGER.info("=== AFTER WARP ===");
+            QT.FLAG_LOGGER.info("Containers:\n{}", WarpDebugLog.formatAllContainers(afterState.containers));
+            QT.FLAG_LOGGER.info("=== CHANGES ===");
+            QT.FLAG_LOGGER.info("{}", debugLog.generateComparison(afterState));
+        }
+
+        WarpDebugLog.end();
+
+        tfbe.toggleDebugLog(DebugLogArgument.TIME_WARP);
+        tfbe.toggleDebugLog(DebugLogArgument.TIME_WARP_DETAIL);
+        tfbe.toggleDebugLog(DebugLogArgument.TIME_WARP_ITEMS);
+        QT.FLAG_LOGGER.info("Verbose warp logging disabled");
     }
 }

--- a/src/main/java/ca/bradj/questown/integration/minecraft/MCAdvanceTime.java
+++ b/src/main/java/ca/bradj/questown/integration/minecraft/MCAdvanceTime.java
@@ -1,0 +1,91 @@
+package ca.bradj.questown.integration.minecraft;
+
+import ca.bradj.questown.core.VillagerUUID;
+import ca.bradj.questown.jobs.JobID;
+import ca.bradj.questown.town.AbstractAdvanceTime;
+import ca.bradj.questown.town.PostDowntimeWarper;
+import ca.bradj.questown.town.Warper;
+import ca.bradj.questown.town.entity.ImportantTicks;
+import ca.bradj.questown.town.entity.TownFlagState;
+import ca.bradj.questown.world.QTWorldAccess;
+import com.google.common.collect.ImmutableList;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.function.Predicate;
+
+/**
+ * Minecraft-specific implementation of AbstractAdvanceTime.
+ * This class bridges the generic advance time logic to Minecraft types.
+ */
+public class MCAdvanceTime extends AbstractAdvanceTime<
+        MCContainer,
+        MCTownItem,
+        MCHeldItem,
+        BlockPos,
+        MCTownState,
+        ServerLevel
+        > {
+
+    private final ImportantTicks.Config ticksConfig;
+
+    public MCAdvanceTime(long maxDowntimeTicks) {
+        this.ticksConfig = new ImportantTicks.Config(maxDowntimeTicks);
+    }
+
+    /**
+     * Creates the WarperFactory implementation that uses PostDowntimeWarper.
+     * This allows dynamic job resolution during warp.
+     *
+     * @param townWork       The TownFlagState.Work for job resolution
+     * @param townFlagPos    Position of the town flag block
+     * @param roomPositions  Real block positions from town rooms
+     */
+    public static WarperFactory<ServerLevel, MCTownState> createWarperFactory(
+            TownFlagState.Work townWork,
+            BlockPos townFlagPos,
+            Collection<BlockPos> roomPositions,
+            @Nullable QTWorldAccess warpWorld
+    ) {
+        return (work, fallbackJobID, villagerIndex) ->
+                new PostDowntimeWarper(townWork, fallbackJobID, villagerIndex, townFlagPos, roomPositions, warpWorld);
+    }
+
+    @Override
+    protected ImmutableList<Warper.Tick> computeImportantTicks(
+            Work work,
+            VillagerUUID uuid,
+            JobID jobID,
+            Predicate<JobID> downtimeCheck,
+            long downtimeTicks,
+            long ticksPassed,
+            long currentTick
+    ) {
+        ImportantTicks.Result result = ImportantTicks.forVillager(
+                work,
+                uuid,
+                jobID,
+                downtimeCheck,
+                ticksConfig,
+                ticksPassed,
+                currentTick
+        );
+        return result.ticks();
+    }
+
+    @Override
+    protected MCTownState finalizeState(MCTownState state, long currentTick) {
+        return new MCTownState(
+                state.villagers,
+                state.containers,
+                state.workStates,
+                state.workTimers,
+                state.gates,
+                state.knowledge(),
+                state.blocksOfProgress,
+                currentTick
+        );
+    }
+}

--- a/src/main/java/ca/bradj/questown/integration/minecraft/MCTownState.java
+++ b/src/main/java/ca/bradj/questown/integration/minecraft/MCTownState.java
@@ -17,6 +17,10 @@ public class MCTownState extends TownState<MCContainer, MCTownItem, MCHeldItem, 
     // TODO: Move to the base class?
     private final ArrayList<MCHeldItem> knowledge = new ArrayList<>();
 
+    // Tracks items inserted by villagers during warp, for recovery if NO_SUPPLIES is encountered.
+    // Key: villager index, Value: map of (workBlockPos -> list of inserted items)
+    private final ImmutableMap<Integer, ImmutableMap<BlockPos, ImmutableList<MCHeldItem>>> insertedItems;
+
     public MCTownState(
             @NotNull List<VillagerData<MCHeldItem>> villagers,
             @NotNull List<ContainerTarget<MCContainer, MCTownItem>> containers,
@@ -27,8 +31,23 @@ public class MCTownState extends TownState<MCContainer, MCTownItem, MCHeldItem, 
             @NotNull ImmutableMap<UUID, Boolean> blocksOfProgress,
             long worldTimeAtSleep
     ) {
+        this(villagers, containers, workStates, workTimers, gates, knowledge, blocksOfProgress, worldTimeAtSleep, ImmutableMap.of());
+    }
+
+    public MCTownState(
+            @NotNull List<VillagerData<MCHeldItem>> villagers,
+            @NotNull List<ContainerTarget<MCContainer, MCTownItem>> containers,
+            @NotNull ImmutableMap<BlockPos, State> workStates,
+            @NotNull ImmutableMap<BlockPos, Integer> workTimers,
+            @NotNull List<BlockPos> gates,
+            @NotNull ImmutableList<MCHeldItem> knowledge,
+            @NotNull ImmutableMap<UUID, Boolean> blocksOfProgress,
+            long worldTimeAtSleep,
+            @NotNull ImmutableMap<Integer, ImmutableMap<BlockPos, ImmutableList<MCHeldItem>>> insertedItems
+    ) {
         super(villagers, containers, workStates, workTimers, gates, blocksOfProgress, worldTimeAtSleep);
         this.knowledge.addAll(knowledge);
+        this.insertedItems = insertedItems;
     }
 
     @Override
@@ -41,7 +60,7 @@ public class MCTownState extends TownState<MCContainer, MCTownItem, MCHeldItem, 
             ImmutableMap<UUID, Boolean> blocksOfProgress,
             long worldTimeAtSleep
     ) {
-        MCTownState mcTownState = new MCTownState(
+        return new MCTownState(
                 villagers,
                 containers,
                 workStates,
@@ -49,9 +68,58 @@ public class MCTownState extends TownState<MCContainer, MCTownItem, MCHeldItem, 
                 gates,
                 ImmutableList.copyOf(knowledge),
                 blocksOfProgress,
-                worldTimeAtSleep
+                worldTimeAtSleep,
+                insertedItems
         );
-        return mcTownState;
+    }
+
+    /**
+     * Records an item that was inserted into a work block by a villager during warp.
+     * Used for item recovery if NO_SUPPLIES is encountered.
+     */
+    public MCTownState withInsertedItem(int villagerIndex, BlockPos workPos, MCHeldItem item) {
+        java.util.Map<Integer, ImmutableMap<BlockPos, ImmutableList<MCHeldItem>>> newOuter = new java.util.HashMap<>(insertedItems);
+        ImmutableMap<BlockPos, ImmutableList<MCHeldItem>> villagerItems = insertedItems.getOrDefault(villagerIndex, ImmutableMap.of());
+        java.util.Map<BlockPos, ImmutableList<MCHeldItem>> newInner = new java.util.HashMap<>(villagerItems);
+        ImmutableList<MCHeldItem> existing = villagerItems.getOrDefault(workPos, ImmutableList.of());
+        newInner.put(workPos, ImmutableList.<MCHeldItem>builder().addAll(existing).add(item).build());
+        newOuter.put(villagerIndex, ImmutableMap.copyOf(newInner));
+        return new MCTownState(
+                villagers,
+                containers,
+                workStates,
+                workTimers,
+                gates,
+                ImmutableList.copyOf(knowledge),
+                blocksOfProgress,
+                worldTimeAtSleep,
+                ImmutableMap.copyOf(newOuter)
+        );
+    }
+
+    /**
+     * Returns all inserted items for a villager (across all work blocks) and creates a new state with them cleared.
+     */
+    public java.util.Map.Entry<MCTownState, ImmutableList<MCHeldItem>> withInsertedItemsCleared(int villagerIndex) {
+        ImmutableMap<BlockPos, ImmutableList<MCHeldItem>> villagerItems = insertedItems.getOrDefault(villagerIndex, ImmutableMap.of());
+        ImmutableList.Builder<MCHeldItem> allItems = ImmutableList.builder();
+        villagerItems.values().forEach(allItems::addAll);
+
+        java.util.Map<Integer, ImmutableMap<BlockPos, ImmutableList<MCHeldItem>>> newOuter = new java.util.HashMap<>(insertedItems);
+        newOuter.remove(villagerIndex);
+
+        MCTownState newState = new MCTownState(
+                villagers,
+                containers,
+                workStates,
+                workTimers,
+                gates,
+                ImmutableList.copyOf(knowledge),
+                blocksOfProgress,
+                worldTimeAtSleep,
+                ImmutableMap.copyOf(newOuter)
+        );
+        return new java.util.AbstractMap.SimpleEntry<>(newState, allItems.build());
     }
 
     public MCTownState withKnowledge(MCHeldItem item) {

--- a/src/main/java/ca/bradj/questown/jobs/ProductionTimeWarper.java
+++ b/src/main/java/ca/bradj/questown/jobs/ProductionTimeWarper.java
@@ -1,5 +1,6 @@
 package ca.bradj.questown.jobs;
 
+import ca.bradj.questown.QT;
 import ca.bradj.questown.jobs.leaver.ContainerTarget;
 import ca.bradj.questown.jobs.production.ProductionStatus;
 import ca.bradj.questown.town.TownState;
@@ -27,8 +28,12 @@ public class ProductionTimeWarper {
     ) {
         Stack<H> stack = new Stack<>();
         itemz.stream().filter(v -> !v.isEmpty() && !v.isLocked()).forEach(stack::add);
+        QT.JOB_LOGGER.debug("[dropIntoContainers] Items to drop: {} (count={})",
+                stack.stream().map(h -> h.get().getShortName()).toList(), stack.size());
+        int droppedCount = 0;
         for (ContainerTarget<C, I> container : containers) {
             if (stack.isEmpty()) {
+                QT.JOB_LOGGER.debug("[dropIntoContainers] Dropped {} items total", droppedCount);
                 return ImmutableList.of();
             }
             if (container.isFull()) {
@@ -36,13 +41,17 @@ public class ProductionTimeWarper {
             }
             for (int i = 0; i < container.size(); i++) {
                 if (container.getItem(i).isEmpty()) {
-                    container.setItem(i, stack.pop().get());
+                    I item = stack.pop().get();
+                    container.setItem(i, item);
+                    droppedCount++;
+                    QT.JOB_LOGGER.debug("[dropIntoContainers] Dropped {} into slot {}", item.getShortName(), i);
                     if (stack.isEmpty()) {
                         break;
                     }
                 }
             }
         }
+        QT.JOB_LOGGER.debug("[dropIntoContainers] Dropped {} items total, {} not deposited", droppedCount, stack.size());
         if (stack.isEmpty()) {
             return ImmutableList.of();
         }
@@ -60,12 +69,16 @@ public class ProductionTimeWarper {
             Supplier<H> emptyFactory
     ) {
         Collection<H> items = getHeldItems(inState, villagerIndex);
+        QT.JOB_LOGGER.debug("[simulateDropLoot] Villager items before drop: {}",
+                items.stream().map(h -> h.isEmpty() ? "empty" : h.get().getShortName()).toList());
         ProductionTimeWarper.Result<H> r = new ProductionTimeWarper.Result<>(status, ImmutableList.copyOf(items));
         Function<ImmutableList<H>, Collection<H>> dropFn = itemz -> ProductionTimeWarper.dropIntoContainers(
                 itemz,
                 inState.containers
         );
         r = ProductionTimeWarper.simulateDropLoot(r, dropFn, emptyFactory);
+        QT.JOB_LOGGER.debug("[simulateDropLoot] Villager items after drop: {}",
+                r.items().stream().map(h -> h.isEmpty() ? "empty" : h.get().getShortName()).toList());
         return inState.withVillagerData(villagerIndex, inState.villagers.get(villagerIndex).withItems(r.items()));
     }
 
@@ -97,6 +110,9 @@ public class ProductionTimeWarper {
             if (toolchk == null) {
                 throw new IllegalStateException("No ingredients or tools required at state " + processingState + ". We shouldn't be collecting.");
             }
+            if (villagerAlreadyHolds(inState, villagerIndex, toolchk)) {
+                return inState;
+            }
             ingr = toolchk;
         }
 
@@ -104,7 +120,7 @@ public class ProductionTimeWarper {
 
         @Nullable Map.Entry<TOWN, I> removeResult = inState.withContainerItemRemoved(i -> fingr.test(grabber.apply(i)));
         if (removeResult == null) {
-            return null; // Item does not exist - collection failed
+            return null;
         }
 
         TOWN outState = removeResult.getKey();
@@ -116,6 +132,19 @@ public class ProductionTimeWarper {
         }
 
         return outState.withVillagerData(villagerIndex, villager);
+    }
+
+    private static <
+            I extends Item<I>,
+            H extends HeldItem<H, I>,
+            TOWN extends TownState<?, I, H, ?, TOWN>
+            > boolean villagerAlreadyHolds(
+            TOWN inState,
+            int villagerIndex,
+            Predicate<H> matcher
+    ) {
+        Collection<H> items = getHeldItems(inState, villagerIndex);
+        return items.stream().filter(h -> !h.isEmpty()).anyMatch(matcher);
     }
 
     public record JobNeeds<I>(

--- a/src/main/java/ca/bradj/questown/jobs/ServerJobsRegistry.java
+++ b/src/main/java/ca/bradj/questown/jobs/ServerJobsRegistry.java
@@ -23,6 +23,7 @@ import ca.bradj.questown.mc.Compat;
 import ca.bradj.questown.mc.Util;
 import ca.bradj.questown.town.NoOpWarper;
 import ca.bradj.questown.town.Warper;
+import ca.bradj.questown.world.QTWorldAccess;
 import ca.bradj.questown.town.workstatus.State;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -51,6 +52,12 @@ import java.util.stream.Collectors;
 import static ca.bradj.questown.jobs.declarative.nomc.WorkSeekerJob.isSeekingWork;
 
 public class ServerJobsRegistry {
+
+    public static boolean isExcludedFromWarp(JobID jobID) {
+        Supplier<Work> w = Works.get(jobID);
+        if (w == null) return false;
+        return w.get().getSpecialGlobalRules().contains(SpecialRules.EXCLUDE_FROM_WARP);
+    }
 
     public static boolean canAlwaysStart(
             UUID uuid,
@@ -455,17 +462,23 @@ public class ServerJobsRegistry {
 
     public static Warper<ServerLevel, MCTownState> getWarper(
             int villagerIndex,
-            JobID jobID
+            JobID jobID,
+            BlockPos townFlagPos,
+            Collection<BlockPos> roomPositions,
+            @Nullable BlockPos assignedWorkBlock,
+            @Nullable QTWorldAccess warpWorld
     ) {
-        return NoOpWarper.INSTANCE;
-
-        // TODO: Bring back warpers
-//        if (isSeekingWork(jobID)) {
-//            return NoOpWarper.INSTANCE;
-//        }
-//        Supplier<Work> w = Works.get(jobID);
-//        assert w != null;
-//        return w.get().warper().apply(new WorksBehaviour.WarpInput(villagerIndex));
+        if (isSeekingWork(jobID)) {
+            return NoOpWarper.INSTANCE;
+        }
+        Supplier<Work> w = Works.get(jobID);
+        if (w == null) {
+            return NoOpWarper.INSTANCE;
+        }
+        return w.get().warper(
+                new WorksBehaviour.WarpInput(villagerIndex, townFlagPos, roomPositions, assignedWorkBlock)
+                        .withWarpWorld(warpWorld)
+        );
     }
 
     public static boolean canSatisfy(

--- a/src/main/java/ca/bradj/questown/jobs/SignalSource.java
+++ b/src/main/java/ca/bradj/questown/jobs/SignalSource.java
@@ -1,5 +1,5 @@
 package ca.bradj.questown.jobs;
 
 public interface SignalSource {
-    Signals getSignal();
+    Signals getSignal(Signals.DayTime dayTime);
 }

--- a/src/main/java/ca/bradj/questown/jobs/Signals.java
+++ b/src/main/java/ca/bradj/questown/jobs/Signals.java
@@ -3,26 +3,61 @@ package ca.bradj.questown.jobs;
 public enum Signals {
     UNDEFINED, MORNING, NOON, EVENING, NIGHT;
 
+    public static final long FULL_DAY_TICKS = 24000;
+    public static final long PRODUCTIVE_DAY_END_TICK = 11500;
     public static final long NIGHT_START_TICK = 22000;
 
     public record DayTime(
             long dayTime
     ) {
         public long ticksBeforeMidnight() {
-            return 24000 - dayTime;
+            return FULL_DAY_TICKS - dayTime;
+        }
+
+        public static DayTime virtualMorning() {
+            return new DayTime(1000);
         }
     }
 
     public static Signals fromDayTime(DayTime gameTime) {
-        long dayTime = gameTime.dayTime % 24000;
+        long dayTime = gameTime.dayTime % FULL_DAY_TICKS;
         if (dayTime < 6000) {
             return Signals.MORNING;
-        } else if (dayTime < 11500) {
+        } else if (dayTime < PRODUCTIVE_DAY_END_TICK) {
             return Signals.NOON;
         } else if (dayTime < NIGHT_START_TICK) {
             return Signals.EVENING;
         } else {
             return Signals.NIGHT;
         }
+    }
+
+    public static long calculateProductiveTicks(long currentWorldTime, long totalTicks) {
+        if (totalTicks <= 0) {
+            return 0;
+        }
+
+        long cursor = currentWorldTime % FULL_DAY_TICKS;
+
+        long firstCycleRemaining = FULL_DAY_TICKS - cursor;
+        if (totalTicks <= firstCycleRemaining) {
+            return countProductiveInRange(cursor, totalTicks);
+        }
+
+        long productive = countProductiveInRange(cursor, firstCycleRemaining);
+        long remaining = totalTicks - firstCycleRemaining;
+
+        long fullCycles = remaining / FULL_DAY_TICKS;
+        productive += fullCycles * PRODUCTIVE_DAY_END_TICK;
+        remaining -= fullCycles * FULL_DAY_TICKS;
+
+        productive += countProductiveInRange(0, remaining);
+        return productive;
+    }
+
+    private static long countProductiveInRange(long startTick, long duration) {
+        long endTick = startTick + duration;
+        long productiveEnd = Math.min(endTick, PRODUCTIVE_DAY_END_TICK);
+        return Math.max(0, productiveEnd - startTick);
     }
 }

--- a/src/main/java/ca/bradj/questown/jobs/declarative/TimeWarpWorldInteraction.java
+++ b/src/main/java/ca/bradj/questown/jobs/declarative/TimeWarpWorldInteraction.java
@@ -1,0 +1,695 @@
+package ca.bradj.questown.jobs.declarative;
+
+import ca.bradj.questown.integration.minecraft.MCContainer;
+import ca.bradj.questown.integration.minecraft.MCHeldItem;
+import ca.bradj.questown.integration.minecraft.MCTownItem;
+import ca.bradj.questown.integration.minecraft.MCTownState;
+import ca.bradj.questown.items.EffectMetaItem;
+import ca.bradj.questown.jobs.*;
+import ca.bradj.questown.jobs.leaver.ContainerTarget;
+import ca.bradj.questown.jobs.production.ProductionStatus;
+import ca.bradj.questown.jobs.production.RoomsNeedingVillagerInput;
+import ca.bradj.questown.jobs.production.RoomsNeedingVillagerInput.NVIRoom;
+import ca.bradj.questown.logic.PredicateCollection;
+import ca.bradj.questown.mc.Compat;
+import ca.bradj.questown.mc.Util;
+import ca.bradj.questown.town.Claim;
+import ca.bradj.questown.town.Effect;
+import ca.bradj.questown.town.TownState;
+import ca.bradj.questown.town.TownVillagerMoods;
+import ca.bradj.questown.town.interfaces.ImmutableWorkStateContainer;
+import ca.bradj.questown.town.workstatus.State;
+import ca.bradj.questown.world.MinecraftWorldAccess;
+import ca.bradj.roomrecipes.adapter.RoomRecipeMatch;
+import ca.bradj.roomrecipes.serialization.MCRoom;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+/**
+ * NOTE: This class is for TIME WARP functionality only.
+ * It is NOT used for realtime job execution logic.
+ * For realtime job execution, see {@link RealtimeWorldInteraction}, {@link TickTownProvider} and {@link DeclarativeJobTicker}.
+ */
+public class TimeWarpWorldInteraction extends
+        AbstractWorldInteraction<TimeWarpWorldInteraction.Inputs, BlockPos, MCTownItem, MCHeldItem, MCTownState> {
+
+    private final BlockPos townPos;
+    private final Collection<BlockPos> roomPositions;
+    private final @Nullable BlockPos assignedWorkBlock;
+    private final Map<ProductionStatus, Collection<String>> specialRulesMap;
+    private final @Nullable ca.bradj.questown.world.QTWorldAccess warpWorld;
+
+    public record Inputs(MCTownState town, ServerLevel level, UUID vUUID) {
+    }
+
+    private final BiFunction<ServerLevel, Collection<MCHeldItem>, Iterable<MCHeldItem>> resultGenerator;
+
+    public TimeWarpWorldInteraction(
+            BlockPos townPos,
+            JobID jobId,
+            int villagerIndex,
+            int interval,
+            int maxState,
+            DeclarativeJobChecks<Inputs, MCHeldItem, MCTownItem, RoomRecipeMatch<MCRoom>, BlockPos> checks,
+            BiFunction<ServerLevel, Collection<MCHeldItem>, Iterable<MCHeldItem>> resultGenerator,
+            Function<TimeWarpWorldInteraction.Inputs, Claim> claimSpots,
+            Map<ProductionStatus, Collection<String>> specialRules,
+            Collection<BlockPos> roomPositions,
+            @Nullable BlockPos assignedWorkBlock,
+            @Nullable ca.bradj.questown.world.QTWorldAccess warpWorld
+    ) {
+        super(jobId, villagerIndex, interval, maxState, checks, claimSpots, specialRules);
+        this.resultGenerator = resultGenerator;
+        this.townPos = townPos;
+        this.roomPositions = roomPositions;
+        this.assignedWorkBlock = assignedWorkBlock;
+        this.specialRulesMap = specialRules;
+        this.warpWorld = warpWorld;
+    }
+
+    private ca.bradj.questown.world.QTWorldAccess resolveWorld(Inputs inputs) {
+        if (warpWorld != null) {
+            return warpWorld;
+        }
+        return MinecraftWorldAccess.silent(inputs.level());
+    }
+
+    public boolean shouldUseRealWorkBlock() {
+        if (assignedWorkBlock == null) {
+            return false;
+        }
+        return specialRulesMap.values().stream()
+                .flatMap(Collection::stream)
+                .anyMatch(rule -> rule.contains("slot"));
+    }
+
+    public @Nullable BlockPos getAssignedWorkBlock() {
+        return assignedWorkBlock;
+    }
+
+    public @Nullable ca.bradj.questown.world.QTWorldAccess getWarpWorld() {
+        return warpWorld;
+    }
+
+    @Override
+    protected int getWorkSpeedOf10(Inputs inputs) {
+        Collection<Effect> effects = inputs.town().getVillager(villagerIndex)
+                                           .getEffectsAndClearExpired(Util.getTick(inputs.level()));
+        return Math.max(TownVillagerMoods.compute(effects) / 10, 1);
+    }
+
+    @Override
+    protected int getAffectedTime(
+            Inputs inputs,
+            Integer nextStepTime
+    ) {
+        return (int) (getTimeFactor(inputs) * nextStepTime);
+    }
+
+    private float getTimeFactor(Inputs inputs) {
+        Collection<Effect> effects = inputs.town().getVillager(villagerIndex)
+                                           .getEffectsAndClearExpired(Util.getTick(inputs.level()));
+        return WorkEffects.calculateTimeFactor(effects);
+    }
+
+    @Override
+    protected MCTownState setHeldItem(
+            Inputs uxtra,
+            MCTownState tuwn,
+            int villagerIndex,
+            int itemIndex,
+            MCHeldItem item
+    ) {
+        if (tuwn == null) {
+            tuwn = uxtra.town();
+        }
+        TownState.VillagerData<MCHeldItem> villager = tuwn.villagers.get(villagerIndex);
+        return tuwn.withVillagerData(villagerIndex, villager.withSetItem(itemIndex, item));
+    }
+
+    @Override
+    protected MCTownState degradeTool(
+            Inputs mcTownState,
+            @Nullable MCTownState tuwn,
+            PredicateCollection<MCTownItem, ?> isExpectedTool
+    ) {
+        if (tuwn == null) {
+            tuwn = mcTownState.town();
+        }
+
+        int i = -1;
+        for (MCHeldItem item : this.getHeldItems(mcTownState, villagerIndex)) {
+            i++;
+            if (!isExpectedTool.test(item.get())) {
+                continue;
+            }
+            ItemStack itemStack = item.get().toQTItemStack();
+            if (!itemStack.isDamageableItem()) {
+                return tuwn;
+            }
+            itemStack.hurt(1, mcTownState.level.getRandom(), null);
+            if (itemStack.getDamageValue() >= itemStack.getMaxDamage()) {
+                itemStack = ItemStack.EMPTY;
+            }
+            return setHeldItem(mcTownState, tuwn, villagerIndex, i, MCHeldItem.fromMCItemStack(itemStack));
+        }
+        return tuwn;
+    }
+
+    @Override
+    protected boolean canInsertItem(
+            Inputs mcTownState,
+            MCHeldItem item,
+            BlockPos bp
+    ) {
+        return true;
+    }
+
+    @Override
+    protected ImmutableWorkStateContainer<BlockPos, MCTownState> getWorkStatuses(
+            Inputs mcTownState
+    ) {
+        return mcTownState.town();
+    }
+
+    @Override
+    protected WorkOutput<MCTownState, WorkPosition<BlockPos>> getWithSurfaceInteractionPos(
+            Inputs inputs,
+            WorkOutput<MCTownState, WorkPosition<BlockPos>> v
+    ) {
+        return Util.workWithSurfaceInteractionPos(inputs.level(), v);
+    }
+
+    @Override
+    protected ArrayList<WorkPosition<BlockPos>> shuffle(
+            Inputs inputs,
+            Collection<WorkPosition<BlockPos>> workSpots
+    ) {
+        return new ArrayList<>(Compat.shuffle(ImmutableList.copyOf(workSpots), inputs.level));
+    }
+
+    @Override
+    protected WorkedSpot<BlockPos> getCurWorkedSpot(
+            Inputs inputs,
+            MCTownState stateSource,
+            BlockPos workSpot
+    ) {
+        int stateAfterWork = stateSource.getJobBlockState(workSpot).processingState();
+        return new WorkedSpot<>(workSpot, stateAfterWork);
+    }
+
+    @Override
+    protected Collection<MCHeldItem> getHeldItems(
+            Inputs mcTownState,
+            int villagerIndex
+    ) {
+        return ProductionTimeWarper.getHeldItems(mcTownState.town(), villagerIndex);
+    }
+
+    @Override
+    protected void triggerCompletionAdvancement(
+            Inputs inputs,
+            BlockPos position
+    ) {
+    }
+
+    @Override
+    protected void preStateChangeHooks(
+            @NotNull MCTownState ctx,
+            Collection<String> rules,
+            Inputs inputs,
+            WorkSpot<Integer, BlockPos> position
+    ) {
+        PreStateChangeHook.run(
+                rules, (pose) -> {
+                }, (job) -> {
+                }
+        );
+    }
+
+    @Override
+    protected @NotNull MCTownState postInsertHook(
+            @NotNull MCTownState mcTownState,
+            Collection<String> rules,
+            Inputs inputs,
+            WorkedSpot<BlockPos> position,
+            MCHeldItem item
+    ) {
+        MCTownState afterHook = PostInsertHook.run(
+                mcTownState,
+                rules,
+                resolveWorld(inputs),
+                position,
+                item.get().toMCItemStack(),
+                ts -> ts.withBOPCleared(inputs.vUUID),
+                inputs.vUUID
+        );
+        if (afterHook == null) {
+            afterHook = mcTownState;
+        }
+        return afterHook.withInsertedItem(villagerIndex, position.workPosition(), item);
+    }
+
+    @Override
+    protected BlockPos getTownPos(Inputs inputs) {
+        return townPos;
+    }
+
+    @Override
+    protected @Nullable MCTownState preExtractHook(
+            MCTownState town,
+            Collection<String> rules,
+            Inputs inputs,
+            BlockPos position
+    ) {
+        Item insertedItem = null; // TODO: Support inserted item history?
+        return PreExtractHook.run(
+                town, rules, resolveWorld(inputs), (ctx, i, s) -> {
+                    Inputs in = new Inputs(ctx, inputs.level(), inputs.vUUID());
+                    return tryGiveItems(in, ImmutableList.of(i), position);
+                }, position, insertedItem, () -> {
+                },
+                () -> roomPositions
+        );
+    }
+
+    @Override
+    protected MCTownState postExtractHook(
+            MCTownState mcTownState,
+            Collection<String> rules,
+            Inputs inputs,
+            BlockPos position,
+            @Nullable MCHeldItem extractedItem
+    ) {
+        return PostExtractHook.run(
+                mcTownState, townPos, rules, resolveWorld(inputs), position, (ctx, itemData) -> {
+                    if (extractedItem == null || extractedItem.isEmpty()) {
+                        return ctx;
+                    }
+                    CompoundTag t = extractedItem.get().toMCItemStack().getOrCreateTag();
+                    itemData.forEach(t::putInt);
+                    return ctx;
+                }, (in, up) -> in
+        );
+    }
+
+    @Override
+    protected MCTownState setJobBlockState(
+            @NotNull Inputs inputs,
+            MCTownState ts,
+            BlockPos position,
+            State fresh
+    ) {
+        return ts.setJobBlockState(position, fresh);
+    }
+
+    @Override
+    protected MCTownState withEffectApplied(
+            @NotNull Inputs inputs,
+            MCTownState ts,
+            MCHeldItem newItem
+    ) {
+        ItemStack s = newItem.get().toQTItemStack();
+        ResourceLocation effect = EffectMetaItem.getEffect(s);
+        return ts.withVillagerData(
+                villagerIndex,
+                ts.getVillager(villagerIndex)
+                  .withEffect(new Effect(effect, EffectMetaItem.getEffectExpiry(s, Util.getTick(inputs.level))))
+        );
+    }
+
+    @Override
+    protected MCTownState withKnowledge(
+            @NotNull Inputs inputs,
+            MCTownState ts,
+            MCHeldItem newItem
+    ) {
+        return ts.withKnowledge(newItem);
+    }
+
+    @Override
+    protected boolean isInstanze(
+            MCTownItem mcTownItem,
+            Class<?> clazz
+    ) {
+        return clazz.isInstance(mcTownItem.get().asItem());
+    }
+
+    @Override
+    protected boolean isMulti(MCTownItem mcTownItem) {
+        return mcTownItem.toQTItemStack().getCount() > 1;
+    }
+
+    @Override
+    protected MCTownState getTown(Inputs inputs) {
+        return inputs.town();
+    }
+
+    @Override
+    protected Iterable<MCHeldItem> getResults(
+            Inputs inputs,
+            Collection<MCHeldItem> mcHeldItems
+    ) {
+        return resultGenerator.apply(inputs.level, mcHeldItems);
+    }
+
+    @Override
+    protected boolean isEntityClose(
+            Inputs mcTownState,
+            BlockPos position
+    ) {
+        return true;
+    }
+
+    @Override
+    protected boolean isReady(Inputs mcTownState) {
+        return true;
+    }
+
+    @Override
+    public boolean tryGrabbingInsertedSupplies(Inputs mcExtra) {
+        return true;
+    }
+
+    @Override
+    public int timesInserted(Inputs inputs) {
+        return 0;
+    }
+
+    @Override
+    protected void registerUnmetNeed(
+            Inputs inputs,
+            NeedsRegistrations.Need ingredientIndex
+    ) {
+    }
+
+    @Override
+    protected void registerUnmetRoom(Inputs inputs) {
+    }
+
+    /**
+     * Injects ticks to simulate time passing during warp.
+     * Ensures ticksSinceLastAction is at least equal to the work interval
+     * so that work can happen on each warp tick.
+     */
+    public void injectTicks(int ticks) {
+        ticksSinceLastAction += ticks;
+        ticksSinceLastAction = Math.max(ticksSinceLastAction, interval);
+    }
+
+    public JobTownProvider<MCRoom> asTownJobs(
+            @NotNull State workStates,
+            RoomRecipeMatch<MCRoom> mcRoom,
+            BlockPos roomBlock,
+            @NotNull ImmutableList<ContainerTarget<MCContainer, MCTownItem>> containers,
+            Supplier<Signals.DayTime> dayTime
+    ) {
+        return new JobTownProvider<MCRoom>() {
+            @Override
+            public Collection<MCRoom> roomsWithCompletedProduct() {
+                if (workStates.processingState() == maxState) {
+                    return ImmutableList.of(mcRoom.room);
+                }
+                return ImmutableList.of();
+            }
+
+            @Override
+            public Collection<MCRoom> roomsAtState(Integer state) {
+                if (workStates.processingState() == state) {
+                    return ImmutableList.of(mcRoom.room);
+                }
+                return ImmutableList.of();
+            }
+
+            @Override
+            public Signals.DayTime getDayTime() {
+                return dayTime.get();
+            }
+
+            @Override
+            public RoomsNeedingVillagerInput<MCRoom, ResourceLocation, BlockPos> roomsNeedingIngredientsByState() {
+                int curState = workStates.processingState();
+                PredicateCollection<MCHeldItem, ?> ings = checks.getIngredientsForStep(curState);
+                if (ings != null) {
+                    return new RoomsNeedingVillagerInput<>(ImmutableMap.of(
+                            curState,
+                            ImmutableList.of(new NVIRoom<>(mcRoom, false))
+                    ));
+                }
+
+                PredicateCollection<MCTownItem, ?> toolChk = checks.getToolsForStep(curState);
+                if (toolChk != null) {
+                    return new RoomsNeedingVillagerInput<>(ImmutableMap.of(
+                            curState,
+                            ImmutableList.of(new NVIRoom<>(mcRoom, false))
+                    ));
+                }
+
+                if (workStates.workLeft() > 0) {
+                    return new RoomsNeedingVillagerInput<>(ImmutableMap.of(
+                            curState,
+                            ImmutableList.of(new NVIRoom<>(mcRoom, false))
+                    ));
+                }
+
+                return new RoomsNeedingVillagerInput<>(ImmutableMap.of());
+            }
+
+            @Override
+            public Map<Integer, LZCD.Dependency<Void>> roomsWithWorkableStatefulBlocks() {
+                ImmutableMap.Builder<Integer, LZCD.Dependency<Void>> b = ImmutableMap.builder();
+                for (int state = 0; state <= maxState; state++) {
+                    final int s = state;
+                    b.put(state, new SimpleDependency("warp room has workable block at state " + state) {
+                        @Override
+                        protected Populated<WithReason<Boolean>> doPopulate(boolean stopOnTrue) {
+                            boolean atState = workStates.processingState() == s;
+                            String reason = atState
+                                    ? "work block at state " + s
+                                    : "work block not at state " + s + " (actual: " + workStates.processingState() + ")";
+                            return new Populated<>(
+                                    "warp workable blocks at state " + s,
+                                    WithReason.always(atState, reason),
+                                    ImmutableMap.of(),
+                                    null
+                            ) {
+                                @Override
+                                protected String stringRep() {
+                                    return "WarpWorkableBlocks[" + s + "]=" + atState;
+                                }
+                            };
+                        }
+
+                        @Override
+                        public String describe() {
+                            return "warp room workable at state " + s;
+                        }
+                    });
+                }
+                return b.build();
+            }
+
+            @Override
+            public LZCD.Dependency<Void> hasSuppliesV2() {
+                return new SimpleDependency("town has supplies for warp") {
+                    @Override
+                    protected Populated<WithReason<Boolean>> doPopulate(boolean stopOnTrue) {
+                        int curState = workStates.processingState();
+                        boolean hasSupplies = false;
+                        String reason = "no supplies found";
+
+                        PredicateCollection<MCHeldItem, ?> ings = checks.getIngredientsForStep(curState);
+                        if (ings != null) {
+                            for (ContainerTarget<MCContainer, MCTownItem> container : containers) {
+                                if (container.hasItem(i -> ings.test(MCHeldItem.fromTown(i)))) {
+                                    hasSupplies = true;
+                                    reason = "container has ingredient for state " + curState;
+                                    break;
+                                }
+                            }
+                        }
+                        if (!hasSupplies) {
+                            PredicateCollection<MCTownItem, ?> toolChk = checks.getToolsForStep(curState);
+                            if (toolChk != null) {
+                                for (ContainerTarget<MCContainer, MCTownItem> container : containers) {
+                                    if (container.hasItem(toolChk::test)) {
+                                        hasSupplies = true;
+                                        reason = "container has tool for state " + curState;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+
+                        final boolean result = hasSupplies;
+                        final String finalReason = reason;
+                        return new Populated<>(
+                                "warp supplies check",
+                                WithReason.always(result, finalReason),
+                                ImmutableMap.of(),
+                                null
+                        ) {
+                            @Override
+                            protected String stringRep() {
+                                return "WarpSupplies [" + result + ": " + finalReason + "]";
+                            }
+                        };
+                    }
+
+                    @Override
+                    public String describe() {
+                        return "hasSuppliesV2 for warp";
+                    }
+                };
+            }
+
+            @Override
+            public boolean isUnfinishedTimeWorkPresent() {
+                return false;
+            }
+
+            @Override
+            public Collection<Integer> getStatesWithUnfinishedItemlessWork() {
+                Collection<Integer> statesWithUnfinishedWork = Jobs.getStatesWithUnfinishedWork(
+                        () -> ImmutableList.of(() -> ImmutableList.of(
+                                roomBlock)), bp -> workStates, (bp) -> true
+                );
+                ImmutableList.Builder<Integer> b = ImmutableList.builder();
+                statesWithUnfinishedWork.forEach(state -> {
+                    if (checks.getToolsForStep(state) == null) {
+                        b.add(state);
+                    }
+                });
+                return b.build();
+            }
+
+            @Override
+            public boolean hasSpace() {
+                return containers.stream().anyMatch(v -> !v.isFull());
+            }
+        };
+    }
+
+    public EntityInvStateProvider<Integer> asInventory(
+            Supplier<Collection<MCHeldItem>> heldItems,
+            Supplier<Integer> state
+    ) {
+        return new EntityInvStateProvider<>() {
+            @Override
+            public boolean inventoryFull() {
+                Collection<MCHeldItem> items = heldItems.get();
+                return items.stream().noneMatch(MCHeldItem::isEmpty);
+            }
+
+            @Override
+            public boolean hasNonSupplyItems() {
+                return JobsClean.hasNonSupplyItems(
+                        heldItems.get(),
+                        state.get(),
+                        checks.getAllRequiredIngredients(),
+                        Jobs.unTown(checks.getAllRequiredTools())
+                );
+            }
+
+            @Override
+            public Map<Integer, SupplyItemStatus> getSupplyItemStatus() {
+                return DeclarativeJobTicker.getSupplyItemStatuses(
+                        heldItems, checks.getAllRequiredIngredients(), (s) -> true,
+                        Jobs.unTown(checks.getAllRequiredTools()), (s) -> true, checks.getAllRequiredWork(), maxState
+                );
+            }
+        };
+    }
+
+    public MCTownState simulateDropLoot(
+            MCTownState inState,
+            ProductionStatus status
+    ) {
+        return ProductionTimeWarper.simulateDropLoot(inState, status, villagerIndex, MCHeldItem::Air);
+    }
+
+    public @Nullable MCTownState simulateCollectSupplies(
+            MCTownState inState,
+            int processingState
+    ) {
+        Map<Integer, ? extends Predicate<MCHeldItem>> ingr = checks.getAllRequiredIngredients();
+        Map<Integer, ? extends Predicate<MCHeldItem>> tool = Jobs.unTown(checks.getAllRequiredTools());
+        return ProductionTimeWarper.simulateCollectSupplies(
+                inState,
+                processingState,
+                villagerIndex,
+                ingr,
+                tool,
+                MCHeldItem::fromTown
+        );
+    }
+
+    @Override
+    protected void iterate(
+            Iterable<MCHeldItem> newItemsSource,
+            Function<MCHeldItem, MCHeldItem> push
+    ) {
+        Util.iterate(newItemsSource, push::apply);
+    }
+
+    /**
+     * Recovers items that were inserted into a work block during warp.
+     * Called when NO_SUPPLIES is encountered, meaning the villager ran out of supplies mid-cycle.
+     * Items are deposited back to containers, or given to the villager if containers are full.
+     *
+     * @return Updated town state with items recovered and tracking cleared
+     */
+    public MCTownState recoverInsertedItems(MCTownState town) {
+        java.util.Map.Entry<MCTownState, ImmutableList<MCHeldItem>> result = town.withInsertedItemsCleared(villagerIndex);
+        MCTownState newState = result.getKey();
+        ImmutableList<MCHeldItem> recoveredItems = result.getValue();
+
+        if (recoveredItems.isEmpty()) {
+            return newState;
+        }
+
+        ImmutableList<MCHeldItem> notDeposited = newState.depositItems(recoveredItems);
+        if (notDeposited.isEmpty()) {
+            return newState;
+        }
+        for (MCHeldItem item : notDeposited) {
+            TownState.VillagerData<MCHeldItem> vd = newState.getVillager(villagerIndex).withAddedItem(item);
+            if (vd != null) {
+                newState = newState.withVillagerData(villagerIndex, vd);
+            }
+        }
+        return newState;
+    }
+
+    /**
+     * Simulates recovering items that were inserted during warp.
+     * Used by the NO_SUPPLIES handler to recover items and reset state.
+     *
+     * @return Updated town state, or null if nothing to recover
+     */
+    public @Nullable MCTownState simulateRecoverInsertedItems(MCTownState inState) {
+        java.util.Map.Entry<MCTownState, ImmutableList<MCHeldItem>> result = inState.withInsertedItemsCleared(villagerIndex);
+        ImmutableList<MCHeldItem> recoveredItems = result.getValue();
+        if (recoveredItems.isEmpty()) {
+            return null;
+        }
+        return recoverInsertedItems(inState);
+    }
+}

--- a/src/main/java/ca/bradj/questown/town/AbstractAdvanceTime.java
+++ b/src/main/java/ca/bradj/questown/town/AbstractAdvanceTime.java
@@ -1,0 +1,269 @@
+package ca.bradj.questown.town;
+
+import ca.bradj.questown.core.UtilClean;
+import ca.bradj.questown.core.VillagerUUID;
+import ca.bradj.questown.jobs.HeldItem;
+import ca.bradj.questown.jobs.Item;
+import ca.bradj.questown.jobs.JobID;
+import ca.bradj.questown.jobs.Signals;
+import ca.bradj.questown.jobs.leaver.ContainerTarget;
+import com.google.common.collect.ImmutableList;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Abstract time warp implementation that contains no Minecraft dependencies.
+ * This class can be used for unit testing without requiring a Minecraft environment.
+ *
+ * @param <C> Container type
+ * @param <I> Item type
+ * @param <H> Held item type
+ * @param <P> Position type
+ * @param <TOWN> Town state type
+ * @param <LEVEL> Level/world type (for loot source)
+ */
+public abstract class AbstractAdvanceTime<
+        C extends ContainerTarget.Container<I>,
+        I extends Item<I>,
+        H extends HeldItem<H, I> & Item<H>,
+        P,
+        TOWN extends TownState<C, I, H, P, TOWN>,
+        LEVEL
+        > {
+
+    /**
+     * Interface for work-related operations during warp.
+     * This allows decoupling from Minecraft-specific job registries.
+     */
+    public interface Work {
+        void recomputeNow();
+
+        @Nullable
+        JobID getRandomFinishableWork(
+                JobID jobID,
+                Signals.DayTime dayTime,
+                long ticksElapsed
+        );
+
+        long getTotalDuration(
+                JobID jobID,
+                VillagerUUID vuid
+        );
+
+        int getWarpTicksPerCycle(
+                JobID jobID,
+                VillagerUUID vuid
+        );
+    }
+
+    /**
+     * Factory interface for creating warpers for individual villagers.
+     */
+    public interface WarperFactory<LEVEL, TOWN extends TownState<?, ?, ?, ?, ?>> {
+        Warper<LEVEL, TOWN> createWarper(
+                Work work,
+                JobID fallbackJobID,
+                int villagerIndex
+        );
+    }
+
+    /**
+     * Interface for cooking resolution during warp.
+     */
+    public interface CookResolver<TOWN, LEVEL> {
+        TOWN resolveCooking(TOWN state, LEVEL level, long ticksPerCycle, long availableTicks);
+    }
+
+    /**
+     * Callback for world-level effects interleaved between
+     * villager warp steps. Called once per distinct tick
+     * boundary during the warp loop.
+     */
+    public interface WarpTickCallback<TOWN> {
+        TOWN onTick(
+                TOWN town, long currentTick, long tickDelta
+        );
+    }
+
+    /**
+     * Interface for logging during warp.
+     */
+    public interface WarpLogger {
+        void log(String message, Object... args);
+
+        void logDetail(String message, Object... args);
+    }
+
+    /**
+     * Result of the advance time operation.
+     */
+    public record Result<TOWN>(
+            TOWN state,
+            long processingTimeMs,
+            int totalWarpSteps
+    ) {}
+
+    /**
+     * Computes important ticks for a villager based on their job.
+     * Subclasses implement this to provide tick computation logic.
+     */
+    protected abstract ImmutableList<Warper.Tick> computeImportantTicks(
+            Work work,
+            VillagerUUID uuid,
+            JobID jobID,
+            Predicate<JobID> downtimeCheck,
+            long downtimeTicks,
+            long ticksPassed,
+            long currentTick
+    );
+
+    /**
+     * Advances time by simulating villager work cycles.
+     *
+     * @param storedState      The town state at the start of the warp
+     * @param ticksPassed      Number of ticks to simulate
+     * @param currentTick      The current game tick (reference point)
+     * @param work             Work interface for job resolution
+     * @param warperFactory    Factory for creating per-villager warpers
+     * @param cookResolver     Optional cooking resolver (can be null)
+     * @param warpTickCallback Optional callback for world-level
+     *                         effects between warp steps (can be null)
+     * @param level            Level/world for loot source
+     * @param downtimeCheck    Predicate to check if a job is a downtime job
+     * @param downtimeTicks    Number of ticks for downtime period
+     * @param logger           Logger for warp operations
+     * @return The updated town state after the warp
+     */
+    public Result<TOWN> advanceTime(
+            TOWN storedState,
+            long ticksPassed,
+            long currentTick,
+            Work work,
+            WarperFactory<LEVEL, TOWN> warperFactory,
+            @Nullable CookResolver<TOWN, LEVEL> cookResolver,
+            @Nullable WarpTickCallback<TOWN> warpTickCallback,
+            LEVEL level,
+            Predicate<JobID> downtimeCheck,
+            long downtimeTicks,
+            WarpLogger logger
+    ) {
+        if (ticksPassed <= 0) {
+            logger.log("Time warp is not applicable (ticksPassed={})", ticksPassed);
+            return new Result<>(storedState, 0, 0);
+        }
+
+        TOWN liveState = storedState;
+        List<TownState.VillagerData<H>> villagers = new ArrayList<>(storedState.villagers);
+
+        List<Map.Entry<Long, Function<TOWN, TOWN>>> warpSteps = collectWarpSteps(
+                villagers, ticksPassed, currentTick, work, warperFactory,
+                level, downtimeCheck, downtimeTicks, logger
+        );
+
+        warpSteps.sort(Map.Entry.comparingByKey());
+        logger.logDetail(
+                "Processing {} total warp steps across {} villagers",
+                warpSteps.size(),
+                villagers.size()
+        );
+
+        if (cookResolver != null) {
+            liveState = cookResolver.resolveCooking(liveState, level, 0, ticksPassed);
+        }
+
+        long before = System.currentTimeMillis();
+        liveState = executeWarpStepsWithHooks(liveState, warpSteps, warpTickCallback, ticksPassed);
+        long after = System.currentTimeMillis();
+
+        logger.log("State after warp of {}: {}", ticksPassed, liveState);
+        logger.log("Warp took {} milliseconds", after - before);
+
+        return new Result<>(
+                finalizeState(liveState, currentTick),
+                after - before,
+                warpSteps.size()
+        );
+    }
+
+    private List<Map.Entry<Long, Function<TOWN, TOWN>>> collectWarpSteps(
+            List<TownState.VillagerData<H>> villagers,
+            long ticksPassed,
+            long currentTick,
+            Work work,
+            WarperFactory<LEVEL, TOWN> warperFactory,
+            LEVEL level,
+            Predicate<JobID> downtimeCheck,
+            long downtimeTicks,
+            WarpLogger logger
+    ) {
+        List<Map.Entry<Long, Function<TOWN, TOWN>>> warpSteps = new ArrayList<>();
+
+        for (int i = 0; i < villagers.size(); i++) {
+            TownState.VillagerData<H> v = villagers.get(i);
+            logger.log(
+                    "[{}] Warping time by {} ticks, starting with journal: {}",
+                    UtilClean.truncateMiddle(v.uuid),
+                    ticksPassed,
+                    v.journal
+            );
+
+            ImmutableList<Warper.Tick> ticks = computeImportantTicks(
+                    work, VillagerUUID.from(v.uuid), v.journal.jobId(),
+                    downtimeCheck, downtimeTicks, ticksPassed, currentTick
+            );
+
+            logger.logDetail(
+                    "[{}] Computed {} important ticks for job {}",
+                    UtilClean.truncateMiddle(v.uuid), ticks.size(), v.journal.jobId()
+            );
+
+            int villagerIndex = i;
+            Warper<LEVEL, TOWN> vWarper = warperFactory.createWarper(
+                    work, v.journal.jobId(), villagerIndex
+            );
+
+            for (Warper.Tick tick : ticks) {
+                warpSteps.add(new AbstractMap.SimpleEntry<>(
+                        tick.tick(),
+                        ts -> vWarper.warp(level, ts, tick.tick(), tick.ticksSincePrevious(), villagerIndex)
+                ));
+            }
+        }
+
+        return warpSteps;
+    }
+
+    private TOWN executeWarpStepsWithHooks(
+            TOWN state,
+            List<Map.Entry<Long, Function<TOWN, TOWN>>> warpSteps,
+            @Nullable WarpTickCallback<TOWN> warpTickCallback,
+            long ticksPassed
+    ) {
+        long lastHookTick = 0;
+        for (Map.Entry<Long, Function<TOWN, TOWN>> warpStep : warpSteps) {
+            long stepTick = warpStep.getKey();
+            if (stepTick > lastHookTick && warpTickCallback != null) {
+                state = warpTickCallback.onTick(state, stepTick, stepTick - lastHookTick);
+                lastHookTick = stepTick;
+            }
+            TOWN affectedState = warpStep.getValue().apply(state);
+            if (affectedState != null) {
+                state = affectedState;
+            }
+        }
+
+        if (warpTickCallback != null && ticksPassed > lastHookTick) {
+            state = warpTickCallback.onTick(state, ticksPassed, ticksPassed - lastHookTick);
+        }
+
+        return state;
+    }
+
+    protected abstract TOWN finalizeState(TOWN state, long currentTick);
+}

--- a/src/main/java/ca/bradj/questown/town/PostDowntimeWarper.java
+++ b/src/main/java/ca/bradj/questown/town/PostDowntimeWarper.java
@@ -1,0 +1,179 @@
+package ca.bradj.questown.town;
+
+import ca.bradj.questown.QT;
+import ca.bradj.questown.integration.minecraft.MCTownState;
+import ca.bradj.questown.jobs.JobID;
+import ca.bradj.questown.jobs.ServerJobsRegistry;
+import ca.bradj.questown.town.entity.TownFlagState;
+import ca.bradj.questown.world.QTWorldAccess;
+import com.google.common.collect.ImmutableList;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Warper for villagers who were in downtime when warp started.
+ * At each warp tick, resolves what work is available and delegates to that job's warper.
+ *
+ * Uses deterministic cycling through preselected jobs instead of random selection,
+ * ensuring every sub-job gets a turn before any repeats.
+ */
+public class PostDowntimeWarper implements Warper<ServerLevel, MCTownState> {
+
+    private final TownFlagState.Work work;
+    private final JobID fallbackJobID;
+    private final int villagerIndex;
+    private final BlockPos townFlagPos;
+    private final Collection<BlockPos> roomPositions;
+    private final @Nullable QTWorldAccess warpWorld;
+
+    public PostDowntimeWarper(
+            TownFlagState.Work work,
+            JobID fallbackJobID,
+            int villagerIndex,
+            BlockPos townFlagPos,
+            Collection<BlockPos> roomPositions,
+            @Nullable QTWorldAccess warpWorld
+    ) {
+        this.work = work;
+        this.fallbackJobID = fallbackJobID;
+        this.villagerIndex = villagerIndex;
+        this.townFlagPos = townFlagPos;
+        this.roomPositions = roomPositions;
+        this.warpWorld = warpWorld;
+    }
+
+    private static final int MAX_STICKY_TICKS = 5;
+
+    private List<JobID> cycleJobs = null;
+    private int cycleIndex = 0;
+    private JobID cachedJob = null;
+    private int stickyTicks = 0;
+    private @Nullable BlockPos assignedFurnace;
+    private boolean furnaceSearched = false;
+
+    public JobID resolveJob(long ticksPassed, boolean villagerHasItems) {
+        if (cycleJobs == null) {
+            work.recomputeNow();
+            cycleJobs = new ArrayList<>(work.getPreselectedJobs(fallbackJobID));
+            cycleJobs.removeIf(ServerJobsRegistry::isExcludedFromWarp);
+            Collections.shuffle(cycleJobs);
+            cycleIndex = 0;
+        }
+
+        if (cachedJob != null && villagerHasItems && stickyTicks < MAX_STICKY_TICKS) {
+            stickyTicks++;
+            return cachedJob;
+        }
+
+        stickyTicks = 0;
+
+        if (cycleJobs.isEmpty()) {
+            cachedJob = fallbackJobID;
+            return cachedJob;
+        }
+
+        cachedJob = cycleJobs.get(cycleIndex % cycleJobs.size());
+        cycleIndex++;
+        return cachedJob;
+    }
+
+    // For testing without MCTownState
+    public JobID resolveJob(long ticksPassed) {
+        return resolveJob(ticksPassed, cachedJob != null);
+    }
+
+    private @Nullable BlockPos findAssignedFurnace(ServerLevel level) {
+        if (furnaceSearched) {
+            return assignedFurnace;
+        }
+        furnaceSearched = true;
+        List<BlockPos> furnaces = new ArrayList<>();
+        for (BlockPos pos : roomPositions) {
+            if (level.getBlockEntity(pos) instanceof AbstractFurnaceBlockEntity) {
+                furnaces.add(pos);
+            }
+        }
+        if (furnaces.isEmpty()) {
+            return null;
+        }
+        assignedFurnace = furnaces.get(villagerIndex % furnaces.size());
+        QT.FLAG_LOGGER.debug(
+                "[PostDowntimeWarper] Assigned furnace {} to villager {} (of {} furnaces)",
+                assignedFurnace, villagerIndex, furnaces.size()
+        );
+        return assignedFurnace;
+    }
+
+    @Override
+    public MCTownState warp(
+            ServerLevel level,
+            MCTownState liveState,
+            long currentTick,
+            long ticksPassed,
+            int villagerNum
+    ) {
+        boolean villagerHasItems = liveState.villagers.get(villagerIndex).journal.items().stream()
+                .anyMatch(item -> !item.isEmpty());
+        JobID resolvedJob = resolveJob(ticksPassed, villagerHasItems);
+
+        if (resolvedJob == null) {
+            return liveState;
+        }
+
+        @Nullable BlockPos furnace = findAssignedFurnace(level);
+
+        Warper<ServerLevel, MCTownState> jobWarper = ServerJobsRegistry.getWarper(
+                villagerIndex,
+                resolvedJob,
+                townFlagPos,
+                roomPositions,
+                furnace,
+                warpWorld
+        );
+
+        if (jobWarper instanceof NoOpWarper) {
+            return liveState;
+        }
+
+        MCTownState result = runToCompletion(resolvedJob, jobWarper, level, liveState, currentTick, ticksPassed, villagerNum);
+        if (result == liveState) {
+            stickyTicks = MAX_STICKY_TICKS;
+        }
+        return result;
+    }
+
+    private static MCTownState runToCompletion(
+            JobID jobId,
+            Warper<ServerLevel, MCTownState> warper,
+            ServerLevel level,
+            MCTownState state,
+            long currentTick,
+            long ticksPassed,
+            int villagerNum
+    ) {
+        for (int i = 0; i < 64; i++) {
+            MCTownState next = warper.warp(level, state, currentTick, ticksPassed, villagerNum);
+            if (next == state) {
+                break;
+            }
+            state = next;
+            if (warper.isCycleComplete()) {
+                break;
+            }
+        }
+        return state;
+    }
+
+    @Override
+    public Collection<Tick> getTicks(long referenceTick, long ticksPassed) {
+        // Ticks are computed by ImportantTicks, not by the warper
+        return ImmutableList.of();
+    }
+}

--- a/src/main/java/ca/bradj/questown/town/WarpDebugLog.java
+++ b/src/main/java/ca/bradj/questown/town/WarpDebugLog.java
@@ -1,0 +1,302 @@
+package ca.bradj.questown.town;
+
+import ca.bradj.questown.core.UtilClean;
+import ca.bradj.questown.integration.minecraft.MCContainer;
+import ca.bradj.questown.integration.minecraft.MCHeldItem;
+import ca.bradj.questown.integration.minecraft.MCTownItem;
+import ca.bradj.questown.integration.minecraft.MCTownState;
+import ca.bradj.questown.jobs.leaver.ContainerTarget;
+import ca.bradj.questown.town.workstatus.State;
+import ca.bradj.roomrecipes.adapter.Positions;
+import com.google.common.collect.ImmutableList;
+import net.minecraft.core.BlockPos;
+
+import java.util.*;
+
+/**
+ * Utility class for verbose time warp debugging output.
+ * Provides:
+ * 1. Formatted container inventory display
+ * 2. Before/after state comparison
+ * 3. Warp event logging
+ */
+public class WarpDebugLog {
+
+    private static final ThreadLocal<WarpDebugLog> CURRENT = new ThreadLocal<>();
+
+    private final List<String> events = new ArrayList<>();
+    private MCTownState beforeState;
+    private boolean enabled = false;
+
+    public WarpDebugLog() {
+    }
+
+    /**
+     * Start a verbose warp session. Call this before warp begins.
+     */
+    public static WarpDebugLog start() {
+        WarpDebugLog log = new WarpDebugLog();
+        log.enabled = true;
+        CURRENT.set(log);
+        return log;
+    }
+
+    /**
+     * End the current verbose warp session.
+     */
+    public static void end() {
+        CURRENT.remove();
+    }
+
+    /**
+     * Get the current verbose log, or null if not in a verbose session.
+     */
+    public static WarpDebugLog current() {
+        return CURRENT.get();
+    }
+
+    /**
+     * Log an event if verbose mode is active.
+     * Safe to call even when not in verbose mode.
+     */
+    public static void event(String format, Object... args) {
+        WarpDebugLog log = CURRENT.get();
+        if (log != null && log.enabled) {
+            log.logEvent(String.format(format, args));
+        }
+    }
+
+    /**
+     * Capture the "before" state for later comparison
+     */
+    public void captureBeforeState(MCTownState state) {
+        this.beforeState = state;
+    }
+
+    /**
+     * Log a warp event (e.g., "Villager collected 1 carrot")
+     */
+    public void logEvent(String event) {
+        events.add(event);
+    }
+
+    /**
+     * Format a single container's inventory for display
+     */
+    public static String formatContainer(ContainerTarget<MCContainer, MCTownItem> container) {
+        BlockPos pos = Positions.ToBlock(container.getPosition(), container.getYPosition());
+        Map<String, Integer> itemCounts = new LinkedHashMap<>();
+
+        for (int i = 0; i < container.size(); i++) {
+            MCTownItem item = container.getItem(i);
+            if (!item.isEmpty()) {
+                String name = item.getShortName();
+                String itemName = extractItemName(name);
+                int qty = item.quantity();
+                itemCounts.merge(itemName, qty, Integer::sum);
+            }
+        }
+
+        if (itemCounts.isEmpty()) {
+            return String.format("  [%d, %d, %d]: (empty)", pos.getX(), pos.getY(), pos.getZ());
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("  [%d, %d, %d]: ", pos.getX(), pos.getY(), pos.getZ()));
+        List<String> items = new ArrayList<>();
+        itemCounts.forEach((name, count) -> items.add(count + "x " + name));
+        sb.append(String.join(", ", items));
+        return sb.toString();
+    }
+
+    /**
+     * Format all containers for display
+     */
+    public static String formatAllContainers(ImmutableList<ContainerTarget<MCContainer, MCTownItem>> containers) {
+        if (containers.isEmpty()) {
+            return "  (no containers)";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (ContainerTarget<MCContainer, MCTownItem> container : containers) {
+            sb.append(formatContainer(container)).append("\n");
+        }
+        return sb.toString().trim();
+    }
+
+    /**
+     * Format a villager's inventory for display
+     */
+    public static String formatVillagerInventory(TownState.VillagerData<MCHeldItem> villager) {
+        String uuid = UtilClean.truncateMiddle(villager.uuid);
+        List<String> items = new ArrayList<>();
+        for (MCHeldItem item : villager.journal.items()) {
+            if (!item.isEmpty()) {
+                items.add(item.getShortName());
+            }
+        }
+        if (items.isEmpty()) {
+            return String.format("  %s: (empty inventory)", uuid);
+        }
+        return String.format("  %s: %s", uuid, String.join(", ", items));
+    }
+
+    /**
+     * Generate a comparison between before and after states
+     */
+    public String generateComparison(MCTownState afterState) {
+        if (beforeState == null) {
+            return "  (no before state captured)";
+        }
+
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("Container Changes:\n");
+        Map<BlockPos, Map<String, Integer>> beforeContents = getContainerContents(beforeState.containers);
+        Map<BlockPos, Map<String, Integer>> afterContents = getContainerContents(afterState.containers);
+
+        Set<BlockPos> allPositions = new HashSet<>();
+        allPositions.addAll(beforeContents.keySet());
+        allPositions.addAll(afterContents.keySet());
+
+        boolean anyContainerChanges = false;
+        for (BlockPos pos : allPositions) {
+            Map<String, Integer> before = beforeContents.getOrDefault(pos, Map.of());
+            Map<String, Integer> after = afterContents.getOrDefault(pos, Map.of());
+            String diff = diffItemCounts(before, after);
+            if (!diff.isEmpty()) {
+                anyContainerChanges = true;
+                sb.append(String.format("  [%d, %d, %d]: %s\n", pos.getX(), pos.getY(), pos.getZ(), diff));
+            }
+        }
+        if (!anyContainerChanges) {
+            sb.append("  (no changes)\n");
+        }
+
+        sb.append("Villager Inventory Changes:\n");
+        boolean anyVillagerChanges = false;
+        for (int i = 0; i < Math.max(beforeState.villagers.size(), afterState.villagers.size()); i++) {
+            Map<String, Integer> before = i < beforeState.villagers.size()
+                    ? getVillagerItems(beforeState.villagers.get(i)) : Map.of();
+            Map<String, Integer> after = i < afterState.villagers.size()
+                    ? getVillagerItems(afterState.villagers.get(i)) : Map.of();
+            String uuid = UtilClean.truncateMiddle(
+                    i < afterState.villagers.size()
+                            ? afterState.villagers.get(i).uuid
+                            : beforeState.villagers.get(i).uuid
+            );
+            String diff = diffItemCounts(before, after);
+            if (!diff.isEmpty()) {
+                anyVillagerChanges = true;
+                sb.append(String.format("  %s: %s\n", uuid, diff));
+            }
+        }
+        if (!anyVillagerChanges) {
+            sb.append("  (no changes)\n");
+        }
+
+        sb.append("Work State Changes:\n");
+        boolean anyWorkChanges = false;
+        Set<BlockPos> allWorkPositions = new HashSet<>();
+        allWorkPositions.addAll(beforeState.workStates.keySet());
+        allWorkPositions.addAll(afterState.workStates.keySet());
+
+        for (BlockPos pos : allWorkPositions) {
+            State beforeWs = beforeState.workStates.get(pos);
+            State afterWs = afterState.workStates.get(pos);
+            if (!Objects.equals(beforeWs, afterWs)) {
+                anyWorkChanges = true;
+                String beforeStr = beforeWs != null ? String.valueOf(beforeWs.processingState()) : "none";
+                String afterStr = afterWs != null ? String.valueOf(afterWs.processingState()) : "none";
+                sb.append(String.format("  [%d, %d, %d]: %s -> %s\n",
+                        pos.getX(), pos.getY(), pos.getZ(), beforeStr, afterStr));
+            }
+        }
+        if (!anyWorkChanges) {
+            sb.append("  (no changes)\n");
+        }
+
+        return sb.toString().trim();
+    }
+
+    /**
+     * Get all logged events
+     */
+    public List<String> getEvents() {
+        return ImmutableList.copyOf(events);
+    }
+
+    /**
+     * Format all events for display
+     */
+    public String formatEvents() {
+        if (events.isEmpty()) {
+            return "  (no events logged)";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (String event : events) {
+            sb.append("  ").append(event).append("\n");
+        }
+        return sb.toString().trim();
+    }
+
+    /**
+     * Clear all logged events
+     */
+    public void clearEvents() {
+        events.clear();
+    }
+
+    private static Map<BlockPos, Map<String, Integer>> getContainerContents(
+            ImmutableList<ContainerTarget<MCContainer, MCTownItem>> containers
+    ) {
+        Map<BlockPos, Map<String, Integer>> result = new HashMap<>();
+        for (ContainerTarget<MCContainer, MCTownItem> container : containers) {
+            BlockPos pos = Positions.ToBlock(container.getPosition(), container.getYPosition());
+            Map<String, Integer> items = new LinkedHashMap<>();
+            for (int i = 0; i < container.size(); i++) {
+                MCTownItem item = container.getItem(i);
+                if (!item.isEmpty()) {
+                    String name = item.getShortName();
+                    String itemName = name.contains("x") ? name.substring(name.indexOf("x") + 1) : name;
+                    items.merge(itemName, item.quantity(), Integer::sum);
+                }
+            }
+            result.put(pos, items);
+        }
+        return result;
+    }
+
+    private static Map<String, Integer> getVillagerItems(TownState.VillagerData<MCHeldItem> villager) {
+        Map<String, Integer> items = new LinkedHashMap<>();
+        for (MCHeldItem item : villager.journal.items()) {
+            if (!item.isEmpty()) {
+                String name = item.getShortName();
+                String itemName = name.contains("x") ? name.substring(name.indexOf("x") + 1) : name;
+                items.merge(itemName, item.quantity(), Integer::sum);
+            }
+        }
+        return items;
+    }
+
+    private static String extractItemName(String shortName) {
+        return shortName.contains("x") ? shortName.substring(shortName.indexOf("x") + 1) : shortName;
+    }
+
+    private static String diffItemCounts(Map<String, Integer> before, Map<String, Integer> after) {
+        Set<String> allItems = new HashSet<>();
+        allItems.addAll(before.keySet());
+        allItems.addAll(after.keySet());
+
+        List<String> changes = new ArrayList<>();
+        for (String item : allItems) {
+            int beforeCount = before.getOrDefault(item, 0);
+            int afterCount = after.getOrDefault(item, 0);
+            int delta = afterCount - beforeCount;
+            if (delta != 0) {
+                String sign = delta > 0 ? "+" : "";
+                changes.add(sign + delta + " " + item);
+            }
+        }
+        return String.join(", ", changes);
+    }
+}

--- a/src/main/java/ca/bradj/questown/town/Warper.java
+++ b/src/main/java/ca/bradj/questown/town/Warper.java
@@ -16,6 +16,8 @@ public interface Warper<LOOT_SOURCE, TOWN extends TownState<?, ?, ?, ?, ?>> {
             int villagerNum
     );
 
+    default boolean isCycleComplete() { return false; }
+
     Collection<Tick> getTicks(long referenceTick, long ticksPassed);
 
 

--- a/src/main/java/ca/bradj/questown/town/entity/ImportantTicks.java
+++ b/src/main/java/ca/bradj/questown/town/entity/ImportantTicks.java
@@ -1,0 +1,164 @@
+package ca.bradj.questown.town.entity;
+
+import ca.bradj.questown.core.VillagerUUID;
+import ca.bradj.questown.jobs.JobID;
+import ca.bradj.questown.jobs.Signals;
+import ca.bradj.questown.town.AbstractAdvanceTime;
+import ca.bradj.questown.town.Warper;
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.function.Predicate;
+
+/**
+ * Computes which game ticks are "important" for a villager's work during time warp.
+ * This class has no Minecraft dependencies and can be unit tested.
+ */
+public class ImportantTicks {
+
+    /**
+     * Adapts TownFlagState.Work to AbstractAdvanceTime.Work.
+     */
+    public static AbstractAdvanceTime.Work adaptWork(TownFlagState.Work w) {
+        return new AbstractAdvanceTime.Work() {
+            @Override
+            public void recomputeNow() {
+                w.recomputeNow();
+            }
+
+            @Override
+            public JobID getRandomFinishableWork(
+                    JobID jobID,
+                    Signals.DayTime dayTime,
+                    long ticksElapsed
+            ) {
+                return w.getRandomFinishableWork(jobID, dayTime, ticksElapsed);
+            }
+
+            @Override
+            public long getTotalDuration(JobID jobID, VillagerUUID vuid) {
+                return w.getTotalDuration(jobID, vuid);
+            }
+
+            @Override
+            public int getWarpTicksPerCycle(JobID jobID, VillagerUUID vuid) {
+                return w.getWarpTicksPerCycle(jobID, vuid);
+            }
+        };
+    }
+    // Default work cycle duration when job is unknown (will be resolved dynamically).
+    // This accounts for real-time overhead: walking, pathfinding, container access, etc.
+    // Real-time observation: ~4 cycles in 10,000 ticks = ~2,500 ticks per cycle.
+    private static final long DEFAULT_WORK_CYCLE_TICKS = 2500;
+
+    // Default ticks per cycle for dynamic resolution (when job isn't known ahead of time).
+    // Each substep can advance production state, so this controls how many state transitions
+    // happen per work cycle. Too high = overproduction, too low = underproduction.
+    // Real-time observation: ~4 cycles in 10,000 ticks with bowl crafting
+    // Bowl crafting needs: 2 ingredients + 10 work + 2 overhead = 14 steps per cycle
+    // With 4 cycle groups over 10,000 ticks, we need ~14 substeps per group (not 140)
+    private static final int DEFAULT_DYNAMIC_TICKS_PER_CYCLE = 28;
+
+    public record Config(
+            long MAX_DOWNTIME_TICKS
+    ) {}
+
+    public record Result(
+            ImmutableList<Warper.Tick> ticks,
+            boolean useDynamicResolution
+    ) {}
+
+    public static Result forVillager(
+            AbstractAdvanceTime.Work w,
+            VillagerUUID uuid,
+            JobID jobID,
+            Predicate<JobID> isDowntime,
+            Config config,
+            long ticksPassed,
+            long startingAtGameTime
+    ) {
+        Collection<Warper.Tick> ticks = new ArrayList<>();
+
+        if (isDowntime.test(jobID)) {
+            return forDowntimeVillager(ticks, config, ticksPassed, startingAtGameTime);
+        }
+
+        w.recomputeNow();
+        JobID resolvedJob = w.getRandomFinishableWork(
+                jobID, Signals.DayTime.virtualMorning(), ticksPassed
+        );
+
+        if (resolvedJob == null) {
+            return withDefaultTickSpacing(ticks, ticksPassed, startingAtGameTime, true);
+        }
+
+        // totalDuration includes real-world overhead (walking, pathfinding, etc.).
+        // Explicit downtime simulation was tested but caused under-production vs real-time.
+        long totalDuration = w.getTotalDuration(resolvedJob, uuid);
+        if (totalDuration <= 0) {
+            totalDuration = DEFAULT_WORK_CYCLE_TICKS;
+        }
+        int ticksPerCycle = Math.max(w.getWarpTicksPerCycle(resolvedJob, uuid), 5);
+
+        generateTicks(ticks, ticksPassed, startingAtGameTime, totalDuration, ticksPerCycle);
+        return new Result(ImmutableList.copyOf(ticks), false);
+    }
+
+    private static Result forDowntimeVillager(
+            Collection<Warper.Tick> ticks,
+            Config config,
+            long ticksPassed,
+            long startingAtGameTime
+    ) {
+        startingAtGameTime += config.MAX_DOWNTIME_TICKS;
+        ticksPassed -= config.MAX_DOWNTIME_TICKS;
+        ticks.add(new Warper.Tick(config.MAX_DOWNTIME_TICKS, config.MAX_DOWNTIME_TICKS));
+
+        if (ticksPassed <= 0) {
+            return new Result(ImmutableList.copyOf(ticks), true);
+        }
+
+        generateTicks(ticks, ticksPassed, startingAtGameTime,
+                DEFAULT_WORK_CYCLE_TICKS, DEFAULT_DYNAMIC_TICKS_PER_CYCLE);
+        return new Result(ImmutableList.copyOf(ticks), true);
+    }
+
+    private static Result withDefaultTickSpacing(
+            Collection<Warper.Tick> ticks,
+            long ticksPassed,
+            long startingAtGameTime,
+            boolean useDynamicResolution
+    ) {
+        generateTicks(ticks, ticksPassed, startingAtGameTime,
+                DEFAULT_WORK_CYCLE_TICKS, DEFAULT_DYNAMIC_TICKS_PER_CYCLE);
+        return new Result(ImmutableList.copyOf(ticks), useDynamicResolution);
+    }
+
+    private static void generateTicks(
+            Collection<Warper.Tick> ticks,
+            long ticksPassed,
+            long startingAtGameTime,
+            long cycleDuration,
+            int ticksPerCycle
+    ) {
+        long stepSpacing = Math.max(1, cycleDuration / ticksPerCycle);
+        long prev = 0;
+        for (int j = 0; j <= ticksPassed; j += (int) cycleDuration) {
+            for (int step = 0; step < ticksPerCycle; step++) {
+                long tickOffset = Math.min(j + (long) step * stepSpacing, ticksPassed);
+                if (tickOffset > ticksPassed) {
+                    break;
+                }
+                long ticksSince = tickOffset - prev;
+                if (ticksSince > 0) {
+                    ticks.add(new Warper.Tick(startingAtGameTime + tickOffset, ticksSince));
+                    prev = tickOffset;
+                }
+            }
+            if (j + cycleDuration > ticksPassed) {
+                break;
+            }
+        }
+    }
+}

--- a/src/main/java/ca/bradj/questown/town/entity/TownFlagBlockEntity.java
+++ b/src/main/java/ca/bradj/questown/town/entity/TownFlagBlockEntity.java
@@ -16,7 +16,7 @@ import ca.bradj.questown.gui.FlagTabsEmbedding;
 import ca.bradj.questown.integration.minecraft.MCContainer;
 import ca.bradj.questown.integration.minecraft.MCHeldItem;
 import ca.bradj.questown.integration.minecraft.MCTownItem;
-import ca.bradj.questown.jobs.Job;
+import ca.bradj.questown.integration.minecraft.MCTownState;
 import ca.bradj.questown.jobs.JobID;
 import ca.bradj.questown.jobs.ServerJobsRegistry;
 import ca.bradj.questown.jobs.WorksBehaviour;
@@ -31,7 +31,6 @@ import ca.bradj.questown.mc.Compat;
 import ca.bradj.questown.mc.Util;
 import ca.bradj.questown.mobs.visitor.VisitorMobEntity;
 import ca.bradj.questown.town.*;
-import ca.bradj.questown.town.TownVillagers;
 import ca.bradj.questown.town.econ.NoMCEconomics;
 import ca.bradj.questown.town.interfaces.*;
 import ca.bradj.questown.town.quests.*;
@@ -99,7 +98,7 @@ public class TownFlagBlockEntity extends BlockEntity implements TownInterface,
     final TownKnownBiomes biomes = new TownKnownBiomes();
     TownHealingHandle healing = new TownHealingHandle();
     private final TownFlagInitialization initializer;
-    private int preferredBuffer; // TODO: Replace with TownVillagerData.FallbackSelector
+    private final TownVillagerData.FallbackSelector fallbackSelector = new TownVillagerData.FallbackSelector();
     private final NoMCEconomics economics = new NoMCEconomics();
     final TownFlagTicker ticker = new TownFlagTicker();
 
@@ -175,7 +174,26 @@ public class TownFlagBlockEntity extends BlockEntity implements TownInterface,
     boolean isInitializedQuests = false;
     boolean changed = false;
 
-    final TownWorkStatusStore jobHandle = new TownWorkStatusStore();
+    /**
+     * Global work status store (used when ownerID is null).
+     * Used by jobs with SHARED_WORK_STATUS special rule.
+     *
+     * IMPORTANT: Global and per-owner stores are INTENTIONALLY SEPARATE and should NOT interact.
+     * They track different work states for different purposes:
+     * - Global store: For shared work where any villager can continue another's work or work simultaneously
+     * - Per-owner stores: For jobs with CLAIM_SPOT rule where work is owned by a specific villager
+     */
+    final TownWorkStatusStore jobHandle = new TownWorkStatusStore(
+            (m, p) -> this.getDebugLogger(QT.FLAG_LOGGER, DebugLogArgument.WORK_STATUS).log(m, p)
+    );
+    /**
+     * Per-owner work status stores (keyed by villager UUID).
+     * Used by jobs with CLAIM_SPOT special rule (which implies owned work states).
+     * Each villager gets their own isolated store so they can claim and work spots independently.
+     *
+     * IMPORTANT: Per-owner stores are INTENTIONALLY SEPARATE from the global store and from each other.
+     * Do NOT copy states between stores - they are meant to be isolated.
+     */
     final Map<UUID, TownWorkStatusStore> jobHandles = new HashMap<>();
 
     final TownWorkHandle workHandle = new TownWorkHandle(subBlocks, getBlockPos());
@@ -303,6 +321,10 @@ public class TownFlagBlockEntity extends BlockEntity implements TownInterface,
     }
 
     public void writeTownData(CompoundTag tag) {
+        writeTownData(tag, true);
+    }
+
+    public void writeTownData(CompoundTag tag, boolean includeEconomicsData) {
         if (level == null) {
             return;
         }
@@ -424,7 +446,10 @@ public class TownFlagBlockEntity extends BlockEntity implements TownInterface,
         return getBlockPos();
     }
 
-    @Override
+    public boolean hasVillagerArrivingInMorning() {
+        return morningRewards.hasPendingSpawnVisitor();
+    }
+
     public void addMorningReward(MCReward ev) {
         this.morningRewards.add(ev);
         this.setChanged();
@@ -591,30 +616,28 @@ public class TownFlagBlockEntity extends BlockEntity implements TownInterface,
             return false;
         };
         Predicate<JobID> canAlwaysStart = p -> ServerJobsRegistry.canAlwaysStart(uuid, p);
-        JobID work = TownVillagers.chooseFromList(
-                canFit,
+        JobID work = possibleWork.nextForVillager(
+                ownerUUID,
+                villager.getJobId(),
                 canAlwaysStart,
+                canFit,
                 requestedResults,
-                td,
-                possibleWork.getFor(villager.getJobId())
+                td
         );
         if (work != null) {
             changeJob.accept(work);
             return true;
         }
 
-        if (preferredBuffer < 100) {
-            preferredBuffer++;
-            return false;
-        }
-        preferredBuffer = 0;
-
-        work = TownVillagers.getPreferredWork(villager.getJobId(), canFit, canAlwaysStart, requestedResults, td);
-        if (work != null) {
-            changeJob.accept(work);
+        JobID fallback = fallbackSelector.tryFallback(
+                1, villager.getJobId(), canFit, canAlwaysStart, requestedResults, td,
+                possibleWork.getFor(villager.getJobId()),
+                jobs -> Compat.shuffle(jobs.iterator(), getServerLevel())
+        );
+        if (fallback != null) {
+            changeJob.accept(fallback);
             return true;
         }
-
         return false;
     }
 
@@ -702,16 +725,7 @@ public class TownFlagBlockEntity extends BlockEntity implements TownInterface,
     public WorkStatusHandle<BlockPos, MCHeldItem> getWorkStatusHandle(
             @Nullable UUID ownerIDOrNullForGlobal
     ) {
-        if (ownerIDOrNullForGlobal == null) {
-            return jobHandle;
-        }
-        TownWorkStatusStore jh = jobHandles.get(ownerIDOrNullForGlobal);
-        if (jh != null) {
-            return jh;
-        }
-        jh = new TownWorkStatusStore();
-        jobHandles.put(ownerIDOrNullForGlobal, jh);
-        return jh;
+        return getRealWorkStatusHandle(ownerIDOrNullForGlobal);
     }
 
     @Override
@@ -799,8 +813,12 @@ public class TownFlagBlockEntity extends BlockEntity implements TownInterface,
         workHandle.openMenuRequested(sender, skipStraightToAdd);
     }
 
-    public void warpTime(int ticks) {
-        state.warp(this, Compat.getBlockStoredTagData(this), getServerLevel(), ticks);
+    public MCTownState warpTime(int ticks) {
+        return state.warp(this, Compat.getBlockStoredTagData(this), getServerLevel(), ticks);
+    }
+
+    public @Nullable MCTownState captureCurrentState() {
+        return state.captureState();
     }
 
     public VillagerHolder getVillagerHandle() {
@@ -828,7 +846,8 @@ public class TownFlagBlockEntity extends BlockEntity implements TownInterface,
     }
 
     public FlagTabsEmbedding.FlagInfo getInfo() {
-        return FlagTabsEmbedding.FlagInfo.dumb(getBlockPos(), bopCount > 0);
+        boolean hasIncomplete = quests.getAll().stream().anyMatch(q -> !q.isComplete());
+        return FlagTabsEmbedding.FlagInfo.withQuestNotification(getBlockPos(), bopCount > 0, hasIncomplete);
     }
 
     public void ejectBlockOfProgress(ServerPlayer sender) {
@@ -843,19 +862,23 @@ public class TownFlagBlockEntity extends BlockEntity implements TownInterface,
         setChanged(sl, blockEntityPos, state);
     }
 
-    public void giveBonusFood(ServerPlayer sp) {
+    public boolean giveBonusFood(ServerPlayer sp) {
         if (givenBonusFood) {
             Compat.sendMessage(sp, Component.translatable("message.questown.bonus_food_only_once"));
-            return;
+            return false;
         }
         BlockPos pos = getBlockPos();
         ItemStack stack = new ItemStack(Items.CARROT, 10);
         level.addFreshEntity(new ItemEntity(level, pos.getX(), pos.getY(), pos.getZ(), stack));
         givenBonusFood = true;
+        return true;
     }
 
     public void toggleDebugLog(String logId) {
         logToggles.compute(logId, (k, v) -> v == null || !v);
+    }
+    public void setDebugLog(String logId, boolean b) {
+        logToggles.put(logId, b);
     }
 
     @Override
@@ -877,5 +900,26 @@ public class TownFlagBlockEntity extends BlockEntity implements TownInterface,
 
     private boolean isDebugLogEnabled(String logId) {
         return logToggles.getOrDefault(logId, false);
+    }
+
+    public AbstractWorkStatusStore<BlockPos, MCHeldItem, MCRoom, ServerLevel> getRealWorkStatusHandle(UUID ownerIDOrNullForGlobal) {
+        if (ownerIDOrNullForGlobal == null) {
+            return jobHandle;
+        }
+        TownWorkStatusStore jh = jobHandles.get(ownerIDOrNullForGlobal);
+        if (jh != null) {
+            return jh;
+        }
+        jh = new TownWorkStatusStore(
+                (m, p) -> this.getDebugLogger(QT.FLAG_LOGGER, DebugLogArgument.WORK_STATUS).log(m, p)
+        );
+        jobHandles.put(ownerIDOrNullForGlobal, jh);
+        // Initialize the new store immediately so work states are available
+        ServerLevel sl = getServerLevel();
+        if (sl != null) {
+            Collection<MCRoom> allRooms = roomsHandle.getAllRoomsIncludingMetaAndFarms();
+            jh.tick(sl, allRooms, 1);
+        }
+        return jh;
     }
 }

--- a/src/main/java/ca/bradj/questown/town/entity/TownFlagState.java
+++ b/src/main/java/ca/bradj/questown/town/entity/TownFlagState.java
@@ -7,21 +7,31 @@ import ca.bradj.questown.core.Config;
 import ca.bradj.questown.core.UtilClean;
 import ca.bradj.questown.core.VillagerUUID;
 import ca.bradj.questown.integration.minecraft.*;
-import ca.bradj.questown.jobs.ImmutableSnapshot;
-import ca.bradj.questown.jobs.ServerJobsRegistry;
+import ca.bradj.questown.jobs.*;
+import ca.bradj.questown.jobs.declarative.DowntimeWork;
+import ca.bradj.questown.jobs.declarative.WarpTickHook;
 import ca.bradj.questown.jobs.leaver.ContainerTarget;
+import ca.bradj.questown.jobs.requests.WorkRequest;
 import ca.bradj.questown.mc.Compat;
 import ca.bradj.questown.mobs.visitor.VisitorMobEntity;
 import ca.bradj.questown.town.TownContainers;
 import ca.bradj.questown.town.TownState;
-import ca.bradj.questown.town.Warper;
+import ca.bradj.questown.town.TownVillagerData;
 import ca.bradj.questown.town.interfaces.TownInterface;
+import ca.bradj.questown.integration.SpecialRulesRegistry;
+import ca.bradj.questown.integration.jobs.JobPhaseModifier;
+import ca.bradj.questown.world.MinecraftWorldAccess;
+import ca.bradj.questown.world.WarpWorldAccess;
 import ca.bradj.roomrecipes.adapter.Positions;
+import ca.bradj.roomrecipes.logic.InclusiveSpaces;
+import ca.bradj.roomrecipes.serialization.MCRoom;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
@@ -33,10 +43,43 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 // This class is NOT encapsulated from MC
 
 public class TownFlagState {
+
+    private static final long MINIMUM_ABSENCE_FOR_SUMMARY = 12000;
+
+    /**
+     * Interface for work-related operations during warp.
+     * This bridges to the job registry and town state.
+     */
+    public interface Work {
+        void recomputeNow();
+
+        @Nullable
+        ca.bradj.questown.jobs.JobID getRandomFinishableWork(
+                ca.bradj.questown.jobs.JobID jobID,
+                ca.bradj.questown.jobs.Signals.DayTime dayTime,
+                long ticksElapsed
+        );
+
+        java.util.List<ca.bradj.questown.jobs.JobID> getPreselectedJobs(
+                ca.bradj.questown.jobs.JobID currentJob
+        );
+
+        long getTotalDuration(
+                ca.bradj.questown.jobs.JobID jobID,
+                ca.bradj.questown.core.VillagerUUID vuid
+        );
+
+        int getWarpTicksPerCycle(
+                ca.bradj.questown.jobs.JobID jobID,
+                ca.bradj.questown.core.VillagerUUID vuid
+        );
+    }
     static final String NBT_TIME_WARP_REFERENCE_TICK = String.format("%s_last_tick", Questown.MODID);
     static final String NBT_TOWN_STATE = String.format("%s_town_state", Questown.MODID);
     private final TownFlagBlockEntity parent;
@@ -114,9 +157,6 @@ public class TownFlagState {
             QT.logBug("NBT had no town state. That's probably a bug. Town state will reset");
         }
 
-
-        ArrayList<TownState.VillagerData<MCHeldItem>> villagers = new ArrayList<>(storedState.villagers);
-
         long ticksPassed = dayTime - storedState.worldTimeAtSleep;
         if (optionalWarpDuration != null) {
             ticksPassed = optionalWarpDuration;
@@ -128,61 +168,170 @@ public class TownFlagState {
 
         ticksPassed = Math.min(ticksPassed, Config.TIME_WARP_MAX_TICKS.get());
 
-        MCTownState liveState = storedState;
-
-        final List<Map.Entry<Long, Function<MCTownState, MCTownState>>> warpSteps = new ArrayList<>();
-
-        for (int i = 0; i < villagers.size(); i++) {
-            TownState.VillagerData<MCHeldItem> v = villagers.get(i);
-            e.getDebugLogger(QT.FLAG_LOGGER, DebugLogArgument.TIME_WARP).log(
-                    "[{}] Warping time by {} ticks, starting with journal: {}",
-                    v.uuid,
-                    ticksPassed,
-                    liveState
-            );
-            Warper<ServerLevel, MCTownState> vWarper = ServerJobsRegistry.getWarper(
-                    i, v.journal.jobId()
-            );
-
-            final int ii = i;
-            vWarper.getTicks(dayTime, ticksPassed).forEach(
-                    tick -> warpSteps.add(new AbstractMap.SimpleEntry<>(
-                            tick.tick(),
-                            ts -> vWarper.warp(sl, ts, tick.tick(), tick.ticksSincePrevious(), ii)
-                    ))
-            );
+        ticksPassed = Signals.calculateProductiveTicks(dayTime, ticksPassed);
+        if (ticksPassed <= 0) {
+            QT.FLAG_LOGGER.info("Time warp contained no productive ticks (all nighttime)");
+            return storedState;
         }
 
-        warpSteps.sort(Map.Entry.comparingByKey());
-        // TODO: Return a collection of lambdas that process chunks of 500?
-        long before = System.currentTimeMillis();
+        Work w = createWork(e, sl);
 
-        for (Map.Entry<Long, Function<MCTownState, MCTownState>> warpStep : warpSteps) {
-            MCTownState affectedState = warpStep.getValue().apply(liveState);
-            if (affectedState != null) {
-                liveState = affectedState;
+        ImmutableList.Builder<BlockPos> roomPosBuilder = ImmutableList.builder();
+        for (MCRoom room : e.roomsHandle.getAllRoomsIncludingMetaAndFarms()) {
+            room.getSpaces().stream()
+                    .flatMap(space -> InclusiveSpaces.getPositions(space, InclusiveSpaces.PositionType.INTERIOR_ONLY).stream())
+                    .forEach(v -> {
+                        BlockPos pos = Positions.ToBlock(v, room.yCoord);
+                        roomPosBuilder.add(pos);
+                        roomPosBuilder.add(pos.above());
+                    });
+        }
+
+        // TODO: Consider pre-allocating roomPositions to jobIds based on JobBlock match and passing them in to advance time
+        ImmutableList<BlockPos> roomPositions = roomPosBuilder.build();
+
+        ImmutableSet<String> rules = collectGlobalRulesForAllVillagerRoots(storedState);
+
+        WarpWorldAccess warpWorld = new WarpWorldAccess(sl, roomPositions);
+
+        MCAdvanceTime.WarpTickCallback<MCTownState> warpCb =
+                (town, tick, delta) -> WarpTickHook.run(
+                        rules,
+                        warpWorld,
+                        town, tick, delta,
+                        () -> roomPositions
+                );
+
+        MCAdvanceTime advancer =
+                new MCAdvanceTime(Config.MAX_DOWNTIME_TICKS.get());
+        MCAdvanceTime.Result<MCTownState> result = advancer.advanceTime(
+                storedState,
+                ticksPassed,
+                dayTime,
+                ImportantTicks.adaptWork(w),
+                MCAdvanceTime.createWarperFactory(w, e.getBlockPos(), roomPositions, warpWorld),
+                null,
+                warpCb,
+                sl,
+                job -> DowntimeWork.matches(job),
+                Config.MAX_DOWNTIME_TICKS.get(),
+                createLogger(e)
+        );
+
+        if (result.state() != null) {
+            warpWorld.applyTo(sl);
+        }
+
+        return result.state();
+    }
+
+    private static ImmutableSet<String> collectGlobalRulesForAllVillagerRoots(
+            MCTownState storedState
+    ) {
+        ImmutableSet<String> activeRoots = storedState.villagers.stream()
+                .map(v -> v.journal.jobId().rootId())
+                .collect(ImmutableSet.toImmutableSet());
+        ImmutableSet.Builder<String> ruleIDs = ImmutableSet.builder();
+        for (JobID id : Works.ids()) {
+            if (!activeRoots.contains(id.rootId())) {
+                continue;
+            }
+            Supplier<ca.bradj.questown.jobs.Work> ws = Works.get(id);
+            if (ws != null) {
+                ruleIDs.addAll(ws.get().getSpecialGlobalRules());
             }
         }
+        return ruleIDs.build();
+    }
 
-        long after = System.currentTimeMillis();
+    /**
+     * Creates the Work implementation that bridges to the TownFlagBlockEntity.
+     */
+    private static Work createWork(TownFlagBlockEntity e, ServerLevel sl) {
+        return new Work() {
+            private final TownVillagerData.FallbackSelector fallbackSelector = new TownVillagerData.FallbackSelector();
 
-        TownInterface.DebugLogger logger =
-                Config.LOG_WARP_RESULT.get() ?
+            @Override
+            public void recomputeNow() {
+                e.getPossibleWork().recomputeNow();
+            }
+
+            @Override
+            public @Nullable JobID getRandomFinishableWork(
+                    JobID currentJob,
+                    Signals.DayTime dayTime,
+                    long ticksElapsed
+            ) {
+                ImmutableList<WorkRequest> requestedResults = e.getWorkHandle().getRequestedResults();
+                WorksBehaviour.TownData td = e.getTownData();
+
+                Predicate<JobID> canFit = p -> ServerJobsRegistry.canFit(null, p, dayTime);
+                Predicate<JobID> canAlwaysStart = p -> ServerJobsRegistry.canAlwaysStart(null, p);
+
+                List<JobID> possibleWork = e.getPossibleWork().getFor(currentJob);
+
+                // First try to choose from preselected jobs that match a request
+                JobID work = TownVillagerData.chooseFromList(
+                        canFit,
+                        canAlwaysStart,
+                        requestedResults,
+                        td,
+                        possibleWork
+                );
+                if (work != null) {
+                    return work;
+                }
+
+                JobID fallback = fallbackSelector.tryFallback(
+                        (int) ticksElapsed, currentJob, canFit, canAlwaysStart, requestedResults, td,
+                        e.getPossibleWork().getFor(currentJob),
+                        jobs -> Compat.shuffle(jobs.iterator(), sl)
+                );
+                if (fallback != null) {
+                    return fallback;
+                }
+                if (fallbackSelector.isBuffering()) {
+                    return currentJob;
+                }
+                return null;
+            }
+
+            @Override
+            public List<JobID> getPreselectedJobs(JobID currentJob) {
+                return e.getPossibleWork().getFor(currentJob);
+            }
+
+            @Override
+            public long getTotalDuration(JobID jobID, VillagerUUID vuid) {
+                return ServerJobsRegistry.getUninitializedJob(jobID, vuid).getJob().getTotalDuration();
+            }
+
+            @Override
+            public int getWarpTicksPerCycle(JobID jobID, VillagerUUID vuid) {
+                return ServerJobsRegistry.getUninitializedJob(jobID, vuid).getJob().getWarpTicksPerCycle();
+            }
+        };
+    }
+
+    /**
+     * Creates a WarpLogger that respects the debug logging configuration.
+     */
+    private static MCAdvanceTime.WarpLogger createLogger(TownFlagBlockEntity e) {
+        return new MCAdvanceTime.WarpLogger() {
+            @Override
+            public void log(String message, Object... args) {
+                TownInterface.DebugLogger logger = Config.LOG_WARP_RESULT.get() ?
                         QT.FLAG_LOGGER::info :
                         e.getDebugLogger(QT.FLAG_LOGGER, DebugLogArgument.TIME_WARP);
-        logger.log("State after warp of {}: {}", ticksPassed, liveState);
-        QT.FLAG_LOGGER.info("Warp took {} milliseconds", after - before);
+                logger.log(message, args);
+            }
 
-        return new MCTownState(
-                liveState.villagers,
-                liveState.containers,
-                liveState.workStates,
-                liveState.workTimers,
-                liveState.gates,
-                liveState.knowledge(),
-                liveState.blocksOfProgress,
-                dayTime
-        );
+            @Override
+            public void logDetail(String message, Object... args) {
+                // Use TIME_WARP for detail logs as well
+                e.getDebugLogger(QT.FLAG_LOGGER, DebugLogArgument.TIME_WARP).log(message, args);
+            }
+        };
     }
 
     static void recoverMobs(
@@ -264,20 +413,27 @@ public class TownFlagState {
         return changes;
     }
 
-    void warp(
+    MCTownState warp(
             TownFlagBlockEntity e,
             CompoundTag flagTag,
             ServerLevel level,
             long timeSinceWake
     ) {
         long levelDayTime = level.getDayTime();
+
+        Map<ResourceLocation, Integer> beforeItems = snapshotContainerItems(e, level);
+
+        MCTownState newState = null;
         try {
-            MCTownState newState = TownFlagState.advanceTime(parent, level, timeSinceWake);
+            newState = TownFlagState.advanceTime(parent, level, timeSinceWake);
             if (newState != null) {
                 e.getDebugLogger(QT.FLAG_LOGGER, DebugLogArgument.TIME_WARP).log("Storing state on {}: {}", e.getUUID(), newState);
                 Compat.getBlockStoredTagData(e).put(NBT_TOWN_STATE, TownStateSerializer.INSTANCE.store(newState));
                 TownFlagState.recoverMobs(parent, level);
+                TownFlagState.restoreWarpVisuals(level, newState);
                 parent.getKnowledgeHandle().registerFoundLoots(newState.knowledge());
+
+                sendWarpSummary(e, level, timeSinceWake, beforeItems);
             }
         } catch (Exception ex) {
             if (Config.CRASH_ON_FAILED_WARP.get()) {
@@ -288,6 +444,110 @@ public class TownFlagState {
         }
         // TODO: Make sure chests get filled/empty
         flagTag.putLong(NBT_TIME_WARP_REFERENCE_TICK, levelDayTime);
+        return newState;
+    }
+
+    private static void restoreWarpVisuals(ServerLevel level, MCTownState state) {
+        ImmutableList<JobPhaseModifier> rules = SpecialRulesRegistry.getAllInstances();
+        for (var blockEntry : state.workStates.entrySet()) {
+            if (blockEntry.getValue().processingState() == 0) {
+                continue;
+            }
+            BlockPos workBlock = blockEntry.getKey();
+            net.minecraft.world.entity.LivingEntity nearest = findNearestVillager(level, state, workBlock);
+            if (nearest == null) {
+                continue;
+            }
+            for (JobPhaseModifier rule : rules) {
+                rule.afterWarpRecovery(level, nearest, workBlock);
+            }
+        }
+    }
+
+    private static net.minecraft.world.entity.LivingEntity findNearestVillager(
+            ServerLevel level,
+            MCTownState state,
+            BlockPos workBlock
+    ) {
+        net.minecraft.world.entity.LivingEntity nearest = null;
+        double nearestDist = Double.MAX_VALUE;
+        for (TownState.VillagerData<?> vData : state.villagers) {
+            net.minecraft.world.entity.Entity entity = level.getEntity(vData.uuid);
+            if (!(entity instanceof net.minecraft.world.entity.LivingEntity living)) {
+                continue;
+            }
+            double dist = workBlock.distSqr(new BlockPos(
+                    (int) vData.xPosition, (int) vData.yPosition, (int) vData.zPosition
+            ));
+            if (dist < nearestDist) {
+                nearestDist = dist;
+                nearest = living;
+            }
+        }
+        return nearest;
+    }
+
+    private Map<ResourceLocation, Integer> snapshotContainerItems(TownFlagBlockEntity e, ServerLevel level) {
+        Map<ResourceLocation, Integer> snapshot = new HashMap<>();
+        ImmutableList<MCTownItem> allStacks = TownContainers.getAllStacks(e, level);
+        for (MCTownItem stack : allStacks) {
+            if (stack.isEmpty()) {
+                continue;
+            }
+            ResourceLocation id = Compat.getItemId(stack.get());
+            snapshot.merge(id, stack.toMCItemStack().getCount(), Integer::sum);
+        }
+        return snapshot;
+    }
+
+    private void sendWarpSummary(
+            TownFlagBlockEntity e,
+            ServerLevel level,
+            long timeSinceWake,
+            Map<ResourceLocation, Integer> beforeItems
+    ) {
+        if (timeSinceWake < MINIMUM_ABSENCE_FOR_SUMMARY) {
+            return;
+        }
+
+        Map<ResourceLocation, Integer> afterItems = snapshotContainerItems(e, level);
+        Map<ResourceLocation, Integer> deltas = new HashMap<>();
+        for (Map.Entry<ResourceLocation, Integer> entry : afterItems.entrySet()) {
+            int before = beforeItems.getOrDefault(entry.getKey(), 0);
+            int delta = entry.getValue() - before;
+            if (delta > 0) {
+                deltas.put(entry.getKey(), delta);
+            }
+        }
+
+        if (deltas.isEmpty()) {
+            return;
+        }
+
+        long daysAway = timeSinceWake / 24000;
+        String dayStr = daysAway == 1 ? "1 day" : daysAway + " days";
+
+        StringBuilder items = new StringBuilder();
+        int count = 0;
+        for (Map.Entry<ResourceLocation, Integer> entry : deltas.entrySet()) {
+            if (count > 0) {
+                items.append(", ");
+            }
+            String itemName = entry.getKey().getPath().replace("_", " ");
+            items.append(entry.getValue()).append(" ").append(itemName);
+            count++;
+            if (count >= 5) {
+                int remaining = deltas.size() - 5;
+                if (remaining > 0) {
+                    items.append(", and ").append(remaining).append(" more");
+                }
+                break;
+            }
+        }
+
+        String message = "While you were away (" + dayStr + "): " + items;
+        e.messages.broadcastMessage(message);
+
     }
 
     private void profileTick(long startTime) {
@@ -323,7 +583,7 @@ public class TownFlagState {
                 QT.FLAG_LOGGER.error("Entity is null at {}, but was expected to be a container", bp);
                 continue;
             }
-            LazyOptional<IItemHandler> cap = entity.getCapability(Compat.ITEM_HANDLER);
+            LazyOptional<IItemHandler> cap = entity.getCapability(Compat.itemHandler());
             if (!cap.isPresent()) {
                 continue;
             }

--- a/src/test/java/ca/bradj/questown/jobs/declarative/TimeWarpWorldInteractionTest.java
+++ b/src/test/java/ca/bradj/questown/jobs/declarative/TimeWarpWorldInteractionTest.java
@@ -1,0 +1,331 @@
+package ca.bradj.questown.jobs.declarative;
+
+import ca.bradj.questown.integration.minecraft.MCHeldItem;
+import ca.bradj.questown.integration.minecraft.MCTownItem;
+import ca.bradj.questown.jobs.GathererJournalTest;
+import ca.bradj.questown.jobs.JobID;
+import ca.bradj.questown.town.Claim;
+import ca.bradj.questown.town.interfaces.ImmutableWorkStateContainer;
+import ca.bradj.questown.town.workstatus.State;
+import ca.bradj.roomrecipes.adapter.RoomRecipeMatch;
+import ca.bradj.roomrecipes.core.space.Position;
+import ca.bradj.roomrecipes.serialization.MCRoom;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import net.minecraft.core.BlockPos;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+/**
+ * Tests for time warp interval behavior.
+ * <p>
+ * These tests verify that the injectTicks mechanism properly handles the case where
+ * consecutive warp ticks have small ticksPassed values but the job has a larger interval.
+ * <p>
+ * The bug (fixed in commit 28ad8a54):
+ * - During warp, each tick creates a new TimeWarpWorldInteraction with ticksSinceLastAction=0
+ * - If ticksPassed (e.g., 1) is less than interval (e.g., 50), work would be skipped
+ * - The fix ensures ticksSinceLastAction is set to at least interval so work always proceeds during warp
+ * <p>
+ * This class contains two types of tests:
+ * 1. Tests that verify the actual TimeWarpWorldInteraction.injectTicks() behavior
+ * 2. Integration tests using IntervalAwareTestWorldInteraction
+ */
+class TimeWarpWorldInteractionTest {
+
+    // ===================================================================================
+    // PART 1: Tests for actual TimeWarpWorldInteraction.injectTicks() behavior
+    // These tests will FAIL on the buggy code and PASS when the fix is applied
+    // ===================================================================================
+
+    /**
+     * Creates a minimal TimeWarpWorldInteraction for testing injectTicks().
+     * Uses null/minimal values where possible since we're only testing the tick injection logic.
+     */
+    private TimeWarpWorldInteraction createMinimalTimeWarpWorldInteraction(int interval) {
+        // Create minimal DeclarativeJobChecks with proper types
+        DeclarativeJobChecks<TimeWarpWorldInteraction.Inputs, MCHeldItem, MCTownItem, RoomRecipeMatch<MCRoom>, BlockPos> checks =
+                new DeclarativeJobChecks<>(
+                        ImmutableMap.of(), // no ingredients
+                        ImmutableMap.of(), // no ingredient quantities
+                        ImmutableMap.of(), // no tools
+                        ImmutableMap.of(), // no work
+                        ImmutableMap.of(), // no time
+                        room -> true,
+                        block -> true
+                );
+
+        return new TimeWarpWorldInteraction(
+                BlockPos.ZERO, // townPos
+                new JobID("test", "test"), // jobId
+                0, // villagerIndex
+                interval, // interval - THE KEY PARAMETER
+                0, // maxState
+                checks,
+                (level, items) -> ImmutableList.of(), // resultGenerator
+                inputs -> null, // claimSpots
+                ImmutableMap.of(), // specialRules
+                ImmutableList.of(), // roomPositions
+                null, // assignedWorkBlock
+                null  // warpWorld
+        );
+    }
+
+    /**
+     * Uses reflection to get the ticksSinceLastAction field value.
+     */
+    private int getTicksSinceLastAction(TimeWarpWorldInteraction wi) throws Exception {
+        Field field = AbstractWorldInteraction.class.getDeclaredField("ticksSinceLastAction");
+        field.setAccessible(true);
+        return field.getInt(wi);
+    }
+
+    /**
+     * CRITICAL TEST: This test verifies the actual TimeWarpWorldInteraction.injectTicks() behavior.
+     * <p>
+     * On the BUGGY code (current): ticksSinceLastAction will be 1, which is < interval (50)
+     * → This test will FAIL because we assert ticksSinceLastAction >= interval
+     * <p>
+     * On the FIXED code: ticksSinceLastAction will be 50, which is >= interval (50)
+     * → This test will PASS
+     */
+    @Test
+    void injectTicks_shouldSetTicksSinceLastActionToAtLeastInterval() throws Exception {
+        int interval = 50; // Simulates bowl crafting cooldown
+        int ticksPassed = 1; // Simulates consecutive warp ticks
+
+        TimeWarpWorldInteraction wi = createMinimalTimeWarpWorldInteraction(interval);
+
+        // Verify initial state
+        int initialTicks = getTicksSinceLastAction(wi);
+        Assertions.assertEquals(0, initialTicks, "Initial ticksSinceLastAction should be 0");
+
+        // Call injectTicks with small value
+        wi.injectTicks(ticksPassed);
+
+        // Get the result
+        int resultTicks = getTicksSinceLastAction(wi);
+
+        // THE KEY ASSERTION: ticksSinceLastAction should be >= interval
+        // This will FAIL on buggy code (result = 1) and PASS on fixed code (result = 50)
+        Assertions.assertTrue(
+                resultTicks >= interval,
+                String.format(
+                        "After injectTicks(%d), ticksSinceLastAction should be >= interval (%d), but was %d. " +
+                        "This indicates the fix from commit 28ad8a54 has not been applied.",
+                        ticksPassed, interval, resultTicks
+                )
+        );
+    }
+
+    /**
+     * CRITICAL TEST: This test simulates the bowl warping scenario with the real injectTicks().
+     * <p>
+     * Each warp tick creates a new TimeWarpWorldInteraction with ticksSinceLastAction=0.
+     * With the buggy code, calling injectTicks(1) leaves ticksSinceLastAction=1, which fails
+     * the interval check (1 < 50).
+     * <p>
+     * This test counts how many times work would happen over 200 warp ticks.
+     * - Buggy code: 0 work cycles (because 1 < 50 every tick)
+     * - Fixed code: 200 work cycles (because 50 >= 50 every tick)
+     */
+    @Test
+    void bowlWarping_shouldAllowWorkOnEveryWarpTick() throws Exception {
+        int interval = 50;
+        int totalWarpTicks = 200;
+        int ticksPerWarpIteration = 1;
+        int workCount = 0;
+
+        for (int t = 0; t < totalWarpTicks; t += ticksPerWarpIteration) {
+            // Simulate fresh TimeWarpWorldInteraction each tick (this is what happens during warp)
+            TimeWarpWorldInteraction wi = createMinimalTimeWarpWorldInteraction(interval);
+
+            // Call the real injectTicks method
+            wi.injectTicks(ticksPerWarpIteration);
+
+            // Check if work would happen (ticksSinceLastAction >= interval)
+            int ticksSinceLastAction = getTicksSinceLastAction(wi);
+            if (ticksSinceLastAction >= interval) {
+                workCount++;
+            }
+        }
+
+        // THE KEY ASSERTION: work should happen on EVERY tick
+        // Buggy code: workCount = 0 (FAIL)
+        // Fixed code: workCount = 200 (PASS)
+        Assertions.assertEquals(
+                totalWarpTicks,
+                workCount,
+                String.format(
+                        "Work should happen on every warp tick (%d total), but only happened %d times. " +
+                        "This indicates the fix from commit 28ad8a54 has not been applied.",
+                        totalWarpTicks, workCount
+                )
+        );
+    }
+
+    /**
+     * Baseline test: Verifies that when ticks >= interval, work happens correctly.
+     * This test should pass on both buggy and fixed code.
+     */
+    @Test
+    void injectTicks_shouldAllowWork_whenTicksGreaterOrEqualToInterval() throws Exception {
+        int interval = 50;
+        int ticksPassed = 100; // Greater than interval
+
+        TimeWarpWorldInteraction wi = createMinimalTimeWarpWorldInteraction(interval);
+        wi.injectTicks(ticksPassed);
+
+        int resultTicks = getTicksSinceLastAction(wi);
+
+        // When ticks >= interval, both implementations should allow work
+        Assertions.assertTrue(
+                resultTicks >= interval,
+                String.format("ticksSinceLastAction (%d) should be >= interval (%d)", resultTicks, interval)
+        );
+    }
+
+    // ===================================================================================
+    // PART 2: Integration tests using TestWorldInteraction subclass
+    // These tests demonstrate the expected behavior
+    // ===================================================================================
+
+    /**
+     * A TestWorldInteraction that supports configurable interval, mimicking TimeWarpWorldInteraction.
+     */
+    static class IntervalAwareTestWorldInteraction extends TestWorldInteraction {
+        private final int configuredInterval;
+
+        public IntervalAwareTestWorldInteraction(
+                int interval,
+                ValidatedInventoryHandle<GathererJournalTest.TestItem> inventory,
+                ImmutableWorkStateContainer<Position, Boolean> workStatuses,
+                Supplier<Claim> claim
+        ) {
+            super(
+                    0, ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(),
+                    ImmutableMap.of(), ImmutableMap.of(),
+                    inventory, workStatuses, claim
+            );
+            this.configuredInterval = interval;
+        }
+
+        public void injectTicks_buggy(int ticks) {
+            ticksSinceLastAction += ticks;
+        }
+
+        public void injectTicks_fixed(int ticks) {
+            ticksSinceLastAction += ticks;
+            ticksSinceLastAction = Math.max(ticksSinceLastAction, configuredInterval);
+        }
+
+        public void resetTicksSinceLastAction() {
+            ticksSinceLastAction = 0;
+        }
+
+        public int getTicksSinceLastAction() {
+            return ticksSinceLastAction;
+        }
+
+        public boolean wouldWorkHappen() {
+            return ticksSinceLastAction >= configuredInterval;
+        }
+    }
+
+    @NotNull
+    private static ImmutableWorkStateContainer<Position, Boolean> testWorkStateContainer() {
+        HashMap<Position, State> ztate = new HashMap<>();
+        return new ImmutableWorkStateContainer<>() {
+            @Override
+            public @Nullable State getJobBlockState(Position bp) {
+                return ztate.get(bp);
+            }
+
+            @Override
+            public ImmutableMap<Position, State> getAll() {
+                return ImmutableMap.copyOf(ztate);
+            }
+
+            @Override
+            public Boolean setJobBlockState(Position bp, State bs) {
+                ztate.put(bp, bs);
+                return true;
+            }
+
+            @Override
+            public Boolean setJobBlockStateWithTimer(Position bp, State bs, int ticksToNextState) {
+                ztate.put(bp, bs);
+                return true;
+            }
+
+            @Override
+            public Boolean clearState(Position bp) {
+                ztate.remove(bp);
+                return true;
+            }
+
+            @Override
+            public boolean claimSpot(Position bp, Claim claim) {
+                return true;
+            }
+
+            @Override
+            public void clearClaim(Position position) {
+            }
+
+            @Override
+            public boolean canClaim(Position position, Supplier<Claim> makeClaim) {
+                return true;
+            }
+        };
+    }
+
+    private static ValidatedInventoryHandle<GathererJournalTest.TestItem> emptyInventory() {
+        return ValidatedInventoryHandle.unvalidated(new InventoryHandle<GathererJournalTest.TestItem>() {
+            @Override
+            public Collection<GathererJournalTest.TestItem> getItems() {
+                return ImmutableList.of(new GathererJournalTest.TestItem(""));
+            }
+
+            @Override
+            public void set(int ii, GathererJournalTest.TestItem shrink) {
+            }
+        });
+    }
+
+    /**
+     * This test demonstrates the difference between buggy and fixed behavior using TestWorldInteraction.
+     */
+    @Test
+    void demonstrateBuggyVsFixedBehavior() {
+        int interval = 50;
+        int ticksPassed = 1;
+
+        IntervalAwareTestWorldInteraction wi = new IntervalAwareTestWorldInteraction(
+                interval,
+                emptyInventory(),
+                testWorkStateContainer(),
+                () -> new Claim(UUID.randomUUID(), 100)
+        );
+
+        // Buggy behavior: ticksSinceLastAction = 1, work does NOT happen
+        wi.resetTicksSinceLastAction();
+        wi.injectTicks_buggy(ticksPassed);
+        Assertions.assertFalse(wi.wouldWorkHappen(),
+                "Buggy implementation: work should NOT happen when ticksSinceLastAction (1) < interval (50)");
+
+        // Fixed behavior: ticksSinceLastAction = 50, work DOES happen
+        wi.resetTicksSinceLastAction();
+        wi.injectTicks_fixed(ticksPassed);
+        Assertions.assertTrue(wi.wouldWorkHappen(),
+                "Fixed implementation: work SHOULD happen when ticksSinceLastAction (50) >= interval (50)");
+    }
+}

--- a/src/test/java/ca/bradj/questown/town/AbstractAdvanceTimeTest.java
+++ b/src/test/java/ca/bradj/questown/town/AbstractAdvanceTimeTest.java
@@ -1,0 +1,244 @@
+package ca.bradj.questown.town;
+
+import ca.bradj.questown.core.VillagerUUID;
+import ca.bradj.questown.jobs.JobID;
+import ca.bradj.questown.jobs.Signals;
+import ca.bradj.questown.town.entity.ImportantTicks;
+import ca.bradj.questown.town.entity.TownFlagState;
+import com.google.common.collect.ImmutableList;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Tests for AbstractAdvanceTime interfaces and ImportantTicks integration.
+ * These tests verify the core time warp abstractions work without Minecraft dependencies.
+ */
+class AbstractAdvanceTimeTest {
+
+    private static final JobID TEST_JOB = new JobID("test", "crafter");
+    private static final VillagerUUID TEST_VILLAGER = VillagerUUID.from(UUID.randomUUID());
+
+    /**
+     * Test Work implementation for AbstractAdvanceTime.Work - core interface for job resolution
+     */
+    static class TestWork implements AbstractAdvanceTime.Work {
+        boolean recomputeCalled = false;
+        int getRandomFinishableWorkCalls = 0;
+        int getTotalDurationCalls = 0;
+        int getWarpTicksPerCycleCalls = 0;
+
+        @Override
+        public void recomputeNow() {
+            recomputeCalled = true;
+        }
+
+        @Override
+        public @Nullable JobID getRandomFinishableWork(JobID jobID, Signals.DayTime dayTime, long ticksElapsed) {
+            getRandomFinishableWorkCalls++;
+            return TEST_JOB;
+        }
+
+        @Override
+        public long getTotalDuration(JobID jobID, VillagerUUID vuid) {
+            getTotalDurationCalls++;
+            return 1000;
+        }
+
+        @Override
+        public int getWarpTicksPerCycle(JobID jobID, VillagerUUID vuid) {
+            getWarpTicksPerCycleCalls++;
+            return 10;
+        }
+    }
+
+    /**
+     * Test Work implementation for TownFlagState.Work - for use with ImportantTicks.adaptWork()
+     */
+    static class TestFlagStateWork implements TownFlagState.Work {
+        boolean recomputeCalled = false;
+        int getRandomFinishableWorkCalls = 0;
+        int getTotalDurationCalls = 0;
+        int getWarpTicksPerCycleCalls = 0;
+
+        @Override
+        public void recomputeNow() {
+            recomputeCalled = true;
+        }
+
+        @Override
+        public @Nullable JobID getRandomFinishableWork(JobID jobID, Signals.DayTime dayTime, long ticksElapsed) {
+            getRandomFinishableWorkCalls++;
+            return TEST_JOB;
+        }
+
+        @Override
+        public java.util.List<JobID> getPreselectedJobs(JobID currentJob) {
+            return java.util.List.of(TEST_JOB);
+        }
+
+        @Override
+        public long getTotalDuration(JobID jobID, VillagerUUID vuid) {
+            getTotalDurationCalls++;
+            return 1000;
+        }
+
+        @Override
+        public int getWarpTicksPerCycle(JobID jobID, VillagerUUID vuid) {
+            getWarpTicksPerCycleCalls++;
+            return 10;
+        }
+    }
+
+    /**
+     * Test logger - verifies logging interface works
+     */
+    static class TestLogger implements AbstractAdvanceTime.WarpLogger {
+        List<String> logs = new ArrayList<>();
+        List<String> detailLogs = new ArrayList<>();
+
+        @Override
+        public void log(String message, Object... args) {
+            logs.add(message);
+        }
+
+        @Override
+        public void logDetail(String message, Object... args) {
+            detailLogs.add(message);
+        }
+    }
+
+    @Test
+    void workInterface_shouldBeCallable_withoutMinecraft() {
+        // Arrange
+        TestWork work = new TestWork();
+
+        // Act - Call all methods that would normally call Minecraft registries
+        work.recomputeNow();
+        JobID resolvedJob = work.getRandomFinishableWork(TEST_JOB, new Signals.DayTime(1000), 5000);
+        long duration = work.getTotalDuration(TEST_JOB, TEST_VILLAGER);
+        int ticksPerCycle = work.getWarpTicksPerCycle(TEST_JOB, TEST_VILLAGER);
+
+        // Assert - All methods callable and return expected values
+        Assertions.assertTrue(work.recomputeCalled);
+        Assertions.assertEquals(TEST_JOB, resolvedJob);
+        Assertions.assertEquals(1000, duration);
+        Assertions.assertEquals(10, ticksPerCycle);
+    }
+
+    @Test
+    void warpLogger_shouldLogMessages_withoutMinecraft() {
+        // Arrange
+        TestLogger logger = new TestLogger();
+
+        // Act
+        logger.log("Processing {} villagers", 5);
+        logger.logDetail("Villager {} at tick {}", "v1", 1000);
+
+        // Assert
+        Assertions.assertEquals(1, logger.logs.size());
+        Assertions.assertEquals(1, logger.detailLogs.size());
+    }
+
+    @Test
+    void importantTicks_shouldComputeTicks_usingWorkInterface() {
+        // Arrange - Use TownFlagState.Work which can be adapted
+        TestFlagStateWork work = new TestFlagStateWork();
+        ImportantTicks.Config config = new ImportantTicks.Config(5000);
+
+        // Act - Use ImportantTicks with our test Work implementation adapted to AbstractAdvanceTime.Work
+        ImportantTicks.Result result = ImportantTicks.forVillager(
+                ImportantTicks.adaptWork(work), // Adapt TownFlagState.Work to AbstractAdvanceTime.Work
+                TEST_VILLAGER,
+                TEST_JOB,
+                job -> false, // Not downtime
+                config,
+                10000, // ticksPassed
+                0 // startingAtGameTime
+        );
+
+        // Assert
+        Assertions.assertFalse(result.ticks().isEmpty(), "Should generate ticks");
+        Assertions.assertTrue(work.recomputeCalled, "Should call recomputeNow");
+        Assertions.assertTrue(work.getRandomFinishableWorkCalls > 0, "Should call getRandomFinishableWork");
+        Assertions.assertTrue(work.getTotalDurationCalls > 0, "Should call getTotalDuration");
+        Assertions.assertTrue(work.getWarpTicksPerCycleCalls > 0, "Should call getWarpTicksPerCycle");
+    }
+
+    @Test
+    void warperTickRecord_shouldBeCreatable_withoutMinecraft() {
+        // Arrange & Act
+        Warper.Tick tick = new Warper.Tick(1000, 100);
+
+        // Assert
+        Assertions.assertEquals(1000, tick.tick());
+        Assertions.assertEquals(100, tick.ticksSincePrevious());
+    }
+
+    @Test
+    void resultRecord_shouldBeCreatable_withoutMinecraft() {
+        // Arrange & Act
+        AbstractAdvanceTime.Result<String> result = new AbstractAdvanceTime.Result<>(
+                "test-state",
+                500,
+                25
+        );
+
+        // Assert
+        Assertions.assertEquals("test-state", result.state());
+        Assertions.assertEquals(500, result.processingTimeMs());
+        Assertions.assertEquals(25, result.totalWarpSteps());
+    }
+
+    @Test
+    void warperFactoryInterface_shouldBeImplementable_withoutMinecraft() {
+        // Arrange
+        AbstractAdvanceTime.WarperFactory<Object, TownState<?, ?, ?, ?, ?>> factory =
+                (work, fallbackJobID, villagerIndex) -> {
+                    // Return a simple warper that tracks calls
+                    return new Warper<>() {
+                        @Override
+                        public TownState<?, ?, ?, ?, ?> warp(Object level, TownState<?, ?, ?, ?, ?> liveState, long currentTick, long ticksPassed, int villagerNum) {
+                            return liveState;
+                        }
+
+                        @Override
+                        public java.util.Collection<Tick> getTicks(long referenceTick, long ticksPassed) {
+                            return ImmutableList.of(new Tick(referenceTick + 100, 100));
+                        }
+                    };
+                };
+
+        // Act
+        Warper<Object, TownState<?, ?, ?, ?, ?>> warper = factory.createWarper(
+                new TestWork(),
+                TEST_JOB,
+                0
+        );
+
+        // Assert
+        Assertions.assertNotNull(warper);
+        Assertions.assertEquals(1, warper.getTicks(0, 1000).size());
+    }
+
+    @Test
+    void cookResolverInterface_shouldBeImplementable_withoutMinecraft() {
+        // Arrange
+        boolean[] called = {false};
+        AbstractAdvanceTime.CookResolver<String, Object> resolver = (state, level, ticksPerCycle, availableTicks) -> {
+            called[0] = true;
+            return state + "_cooked";
+        };
+
+        // Act
+        String result = resolver.resolveCooking("initial", new Object(), 100, 5000);
+
+        // Assert
+        Assertions.assertTrue(called[0]);
+        Assertions.assertEquals("initial_cooked", result);
+    }
+}

--- a/src/test/java/ca/bradj/questown/town/entity/ImportantTicksTest.java
+++ b/src/test/java/ca/bradj/questown/town/entity/ImportantTicksTest.java
@@ -1,0 +1,230 @@
+package ca.bradj.questown.town.entity;
+
+import ca.bradj.questown.core.VillagerUUID;
+import ca.bradj.questown.jobs.JobID;
+import ca.bradj.questown.jobs.Signals;
+import ca.bradj.questown.town.AbstractAdvanceTime;
+import ca.bradj.questown.town.Warper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+/**
+ * Tests for ImportantTicks - the tick computation logic for time warp.
+ * These tests verify the class works without Minecraft dependencies.
+ */
+class ImportantTicksTest {
+
+    private static final JobID TEST_JOB = new JobID("test", "crafter");
+    private static final JobID DOWNTIME_JOB = new JobID("test", "downtime");
+    private static final VillagerUUID TEST_VILLAGER = VillagerUUID.from(UUID.randomUUID());
+
+    /**
+     * Test Work implementation that doesn't depend on Minecraft.
+     */
+    private static class TestWork implements AbstractAdvanceTime.Work {
+        private final long totalDuration;
+        private final int ticksPerCycle;
+        private final JobID resolvedJob;
+
+        TestWork(long totalDuration, int ticksPerCycle, JobID resolvedJob) {
+            this.totalDuration = totalDuration;
+            this.ticksPerCycle = ticksPerCycle;
+            this.resolvedJob = resolvedJob;
+        }
+
+        @Override
+        public void recomputeNow() {
+            // No-op for test
+        }
+
+        @Override
+        public JobID getRandomFinishableWork(JobID jobID, Signals.DayTime dayTime, long ticksElapsed) {
+            return resolvedJob;
+        }
+
+        @Override
+        public long getTotalDuration(JobID jobID, VillagerUUID vuid) {
+            return totalDuration;
+        }
+
+        @Override
+        public int getWarpTicksPerCycle(JobID jobID, VillagerUUID vuid) {
+            return ticksPerCycle;
+        }
+    }
+
+    @Test
+    void forVillager_shouldGenerateTicksForKnownJob() {
+        // Arrange
+        TestWork work = new TestWork(1000, 10, TEST_JOB);
+        ImportantTicks.Config config = new ImportantTicks.Config(5000);
+        long ticksPassed = 5000;
+        long startTime = 0;
+
+        // Act
+        ImportantTicks.Result result = ImportantTicks.forVillager(
+                work,
+                TEST_VILLAGER,
+                TEST_JOB,
+                job -> false, // Not downtime
+                config,
+                ticksPassed,
+                startTime
+        );
+
+        // Assert
+        Assertions.assertFalse(result.useDynamicResolution(), "Should not use dynamic resolution for known job");
+        Assertions.assertFalse(result.ticks().isEmpty(), "Should generate ticks");
+
+        // Verify ticks are in chronological order
+        long prevTick = -1;
+        for (Warper.Tick tick : result.ticks()) {
+            Assertions.assertTrue(tick.tick() > prevTick, "Ticks should be in chronological order");
+            prevTick = tick.tick();
+        }
+    }
+
+    @Test
+    void forVillager_shouldUseDynamicResolution_whenJobCannotBeResolved() {
+        // Arrange - Work that returns null (no finishable work)
+        TestWork work = new TestWork(1000, 10, null);
+        ImportantTicks.Config config = new ImportantTicks.Config(5000);
+        long ticksPassed = 5000;
+        long startTime = 0;
+
+        // Act
+        ImportantTicks.Result result = ImportantTicks.forVillager(
+                work,
+                TEST_VILLAGER,
+                TEST_JOB,
+                job -> false, // Not downtime
+                config,
+                ticksPassed,
+                startTime
+        );
+
+        // Assert
+        Assertions.assertTrue(result.useDynamicResolution(), "Should use dynamic resolution when job can't be resolved");
+        Assertions.assertFalse(result.ticks().isEmpty(), "Should still generate ticks");
+    }
+
+    @Test
+    void forVillager_shouldHandleDowntimeJob() {
+        // Arrange
+        TestWork work = new TestWork(1000, 10, TEST_JOB);
+        ImportantTicks.Config config = new ImportantTicks.Config(2000); // 2000 ticks of downtime
+        long ticksPassed = 5000;
+        long startTime = 0;
+
+        // Act
+        ImportantTicks.Result result = ImportantTicks.forVillager(
+                work,
+                TEST_VILLAGER,
+                DOWNTIME_JOB,
+                job -> job.equals(DOWNTIME_JOB), // This IS a downtime job
+                config,
+                ticksPassed,
+                startTime
+        );
+
+        // Assert
+        Assertions.assertTrue(result.useDynamicResolution(), "Should use dynamic resolution for downtime jobs");
+        Assertions.assertFalse(result.ticks().isEmpty(), "Should still generate ticks after downtime");
+
+        // First tick should be the downtime tick
+        Warper.Tick firstTick = result.ticks().get(0);
+        Assertions.assertEquals(2000, firstTick.tick(), "First tick should be at end of downtime");
+    }
+
+    @Test
+    void forVillager_shouldReturnEmpty_whenOnlyDowntimeRemains() {
+        // Arrange
+        TestWork work = new TestWork(1000, 10, TEST_JOB);
+        ImportantTicks.Config config = new ImportantTicks.Config(5000); // 5000 ticks of downtime
+        long ticksPassed = 3000; // Less than downtime
+        long startTime = 0;
+
+        // Act
+        ImportantTicks.Result result = ImportantTicks.forVillager(
+                work,
+                TEST_VILLAGER,
+                DOWNTIME_JOB,
+                job -> job.equals(DOWNTIME_JOB), // This IS a downtime job
+                config,
+                ticksPassed,
+                startTime
+        );
+
+        // Assert
+        Assertions.assertTrue(result.useDynamicResolution());
+        // Should only have the downtime tick, no work ticks after
+        Assertions.assertEquals(1, result.ticks().size(), "Should only have downtime tick when ticks < downtime");
+    }
+
+    @Test
+    void forVillager_shouldEnforceMinimumTicksPerCycle() {
+        // Arrange - Work that returns very small ticksPerCycle
+        TestWork work = new TestWork(1000, 2, TEST_JOB); // Only 2 ticks per cycle
+        ImportantTicks.Config config = new ImportantTicks.Config(5000);
+        long ticksPassed = 5000;
+        long startTime = 0;
+
+        // Act
+        ImportantTicks.Result result = ImportantTicks.forVillager(
+                work,
+                TEST_VILLAGER,
+                TEST_JOB,
+                job -> false,
+                config,
+                ticksPassed,
+                startTime
+        );
+
+        // Assert - Should have at least 5 ticks per cycle as minimum (enforced in code)
+        // With 5000 ticks and 1000 per cycle, we expect ~5 cycles
+        // Each cycle should have minimum 5 ticks, so at least 20 total
+        Assertions.assertFalse(result.ticks().isEmpty());
+        // Just verify we get ticks and the minimum enforcement doesn't break anything
+        Assertions.assertTrue(result.ticks().size() > 0,
+                "Should generate ticks with minimum enforcement");
+    }
+
+    @Test
+    void adaptWork_shouldCorrectlyAdaptTownFlagStateWork() {
+        // Arrange
+        TownFlagState.Work flagStateWork = new TownFlagState.Work() {
+            @Override
+            public void recomputeNow() {}
+
+            @Override
+            public JobID getRandomFinishableWork(JobID jobID, Signals.DayTime dayTime, long ticksElapsed) {
+                return TEST_JOB;
+            }
+
+            @Override
+            public java.util.List<JobID> getPreselectedJobs(JobID currentJob) {
+                return java.util.List.of(TEST_JOB);
+            }
+
+            @Override
+            public long getTotalDuration(JobID jobID, VillagerUUID vuid) {
+                return 500;
+            }
+
+            @Override
+            public int getWarpTicksPerCycle(JobID jobID, VillagerUUID vuid) {
+                return 8;
+            }
+        };
+
+        // Act
+        AbstractAdvanceTime.Work adapted = ImportantTicks.adaptWork(flagStateWork);
+
+        // Assert
+        Assertions.assertEquals(TEST_JOB, adapted.getRandomFinishableWork(TEST_JOB, new Signals.DayTime(1000), 1000));
+        Assertions.assertEquals(500, adapted.getTotalDuration(TEST_JOB, TEST_VILLAGER));
+        Assertions.assertEquals(8, adapted.getWarpTicksPerCycle(TEST_JOB, TEST_VILLAGER));
+    }
+}


### PR DESCRIPTION
Core warp loop extracted and rebuilt:
- AbstractAdvanceTime: generic, MC-free warp loop with WarpTickCallback
- MCAdvanceTime: MC-specific subclass
- ImportantTicks: computes per-villager warp tick schedule
- PostDowntimeWarper: deterministic job cycling for idle villagers
- TimeWarpWorldInteraction: warp-path world interaction with item recovery
- WarpDebugLog: thread-local verbose warp debugging

Warp behavioral changes:
- Per-job warpers re-enabled (was returning no-op)
- Non-productive time excluded (morning/noon only, ticks 0-11500)
- Warp item recovery: inserted items recovered on NO_SUPPLIES
- Warp summary messages sent to player on return
- Warp command moved to /qt debug warp, verbose option added

Bug fixes:
- Extraction ordering: reset after extraction, not before
- State clobbering: post-insert hooks use current context
- Redundant tool collection prevented