### PR TITLE
Warp-interleaved hooks, rule registrations, and job definition updates

### DIFF
--- a/src/main/java/ca/bradj/questown/_vanilla/DeployFishingHookRule.java
+++ b/src/main/java/ca/bradj/questown/_vanilla/DeployFishingHookRule.java
@@ -72,6 +72,21 @@ public class DeployFishingHookRule extends JobPhaseModifier {
     }
 
     @Override
+    public void afterWarpRecovery(
+            ServerLevel level,
+            LivingEntity villager,
+            BlockPos workBlock
+    ) {
+        if (!(level.getBlockState(workBlock).getBlock() instanceof FishingStationBlock)) {
+            return;
+        }
+        FishingHook hook = deployHere(level, workBlock, villager);
+        if (hook != null) {
+            this.hooks.add(hook);
+        }
+    }
+
+    @Override
     public <CONTEXT> @Nullable CONTEXT beforeExtract(
             CONTEXT ctxInput,
             BeforeExtractEvent<CONTEXT> event

--- a/src/main/java/ca/bradj/questown/_vanilla/VanillaSpecialRules.java
+++ b/src/main/java/ca/bradj/questown/_vanilla/VanillaSpecialRules.java
@@ -4,6 +4,8 @@ import ca.bradj.questown.integration.SpecialRulesRegistry;
 
 public class VanillaSpecialRules {
     public static void register() {
+
+        // This is purely for visual effect. The fisher uses simple loot-based result generation.
         SpecialRulesRegistry.registerSpecialRule(
                 Vanilla.ResourceLocation("deploy_and_retract_fishing_hook"),
                 new DeployFishingHookRule()

--- a/src/main/java/ca/bradj/questown/integration/QuestownSpecialRules.java
+++ b/src/main/java/ca/bradj/questown/integration/QuestownSpecialRules.java
@@ -126,6 +126,24 @@ public final class QuestownSpecialRules {
                 new RandomShortLivedWorkSpot(true, 100)
         );
 
+        // Warp-interleaved hook: simulates crop growth during
+        // time warp. Effects are proportional to tickDelta.
+        SpecialRulesRegistry.registerSpecialRule(
+                Questown.ResourceLocation(
+                        SpecialRules.CROP_GROWTH_WARP
+                ),
+                new GrowCropsWarpRule()
+        );
+
+        // Warp-interleaved hook: advances furnace smelting
+        // during time warp.
+        SpecialRulesRegistry.registerSpecialRule(
+                Questown.ResourceLocation(
+                        SpecialRules.FURNACE_SMELT_WARP
+                ),
+                new SmeltFurnaceWarpRule()
+        );
+
         VanillaSpecialRules.register();
     }
 }

--- a/src/main/java/ca/bradj/questown/integration/jobs/JobPhaseModifier.java
+++ b/src/main/java/ca/bradj/questown/integration/jobs/JobPhaseModifier.java
@@ -3,6 +3,26 @@ package ca.bradj.questown.integration.jobs;
 import ca.bradj.questown.jobs.JobBlockTestContext;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Allows modifying the behavior of job phases via injection through
+ * the SpecialRulesRegistry.
+ *
+ * <h3>Tier system</h3>
+ * Rules fall into one of two tiers:
+ * <ul>
+ *   <li><b>Tier 1 (QT-native)</b>: accesses the world only through
+ *       {@code QTWorldAccess} methods. Works correctly during time warp
+ *       and in unit tests. Implement {@link QTNativeRule} to declare this.</li>
+ *   <li><b>Tier 2 (MC-native)</b>: calls
+ *       {@code event.world().asServerLevel()} to reach Minecraft APIs.
+ *       Must handle a {@code null} return gracefully (warp/test context).
+ *       Do <em>not</em> implement {@link QTNativeRule}.</li>
+ * </ul>
+ * Tier 2 rules are logged at startup by {@link ca.bradj.questown.integration.SpecialRulesRegistry}.
+ *
+ * @see ca.bradj.questown.jobs.declarative.PrePostHooks#processMulti
+ * @see QTNativeRule
+ */
 public abstract class JobPhaseModifier {
 
     @SuppressWarnings("RedundantMethodOverride")
@@ -45,6 +65,19 @@ public abstract class JobPhaseModifier {
 
         @Override
         public void beforeFindJobSite(BeforeFindJobSiteEvent event) {
+        }
+
+        @Override
+        public <X> X onWarpTick(X town, WarpTickEvent event) {
+            return town;
+        }
+
+        @Override
+        public void afterWarpRecovery(
+                net.minecraft.server.level.ServerLevel level,
+                net.minecraft.world.entity.LivingEntity villager,
+                net.minecraft.core.BlockPos workBlock
+        ) {
         }
     };
 
@@ -106,6 +139,40 @@ public abstract class JobPhaseModifier {
     }
     public void beforeMaxTicksJobChange(
             BeforeMaxTicksJobChangeEvent ctx
+    ) {
+    }
+
+    /**
+     * Called between villager warp steps during time warp.
+     * Default returns town unchanged (pass-through).
+     * Override to apply world-level effects like crop growth.
+     *
+     * Unlike beforeExtract (null = didn't handle), this
+     * always chains - every rule runs and the town state
+     * threads through via processMulti. Compute effects
+     * proportionally to {@code event.tickDelta()}, not
+     * assuming any particular call frequency.
+     */
+    public <X> X onWarpTick(X town, WarpTickEvent event) {
+        return town;
+    }
+
+    /**
+     * Called once after time warp completes and villager entities have been
+     * recovered, for each work block that was in active use (processingState > 0)
+     * at warp end.
+     * <p>
+     * Override to restore visual-only effects that were skipped during warp
+     * (e.g. cosmetic entities). The default no-op is appropriate for most rules.
+     *
+     * @param level      the server level (never null - this fires after recovery)
+     * @param villager   the nearest recovered villager entity for this work block
+     * @param workBlock  the active work block position
+     */
+    public void afterWarpRecovery(
+            net.minecraft.server.level.ServerLevel level,
+            net.minecraft.world.entity.LivingEntity villager,
+            net.minecraft.core.BlockPos workBlock
     ) {
     }
 }

--- a/src/main/java/ca/bradj/questown/integration/jobs/WarpTickEvent.java
+++ b/src/main/java/ca/bradj/questown/integration/jobs/WarpTickEvent.java
@@ -1,0 +1,31 @@
+package ca.bradj.questown.integration.jobs;
+
+import ca.bradj.questown.world.QTWorldAccess;
+import net.minecraft.core.BlockPos;
+
+import java.util.Collection;
+import java.util.function.Supplier;
+
+/**
+ * Event record for warp-interleaved hooks. Passed to
+ * {@link JobPhaseModifier#onWarpTick} between villager
+ * warp steps during time warp.
+ *
+ * @param world              World access (QTWorldAccess,
+ *                           not ServerLevel) for testability
+ * @param currentTick        The current simulated game tick
+ * @param tickDelta          Ticks elapsed since last invocation.
+ *                           Hooks should compute effects
+ *                           proportionally to this value,
+ *                           not assume any particular call
+ *                           frequency.
+ * @param workBlockPositions Tracked job block positions from
+ *                           the town's work state registry
+ */
+public record WarpTickEvent(
+        QTWorldAccess world,
+        long currentTick,
+        long tickDelta,
+        Supplier<Collection<BlockPos>> workBlockPositions
+) {
+}

--- a/src/main/java/ca/bradj/questown/jobs/declarative/WarpTickHook.java
+++ b/src/main/java/ca/bradj/questown/jobs/declarative/WarpTickHook.java
@@ -1,0 +1,36 @@
+package ca.bradj.questown.jobs.declarative;
+
+import ca.bradj.questown.integration.SpecialRulesRegistry;
+import ca.bradj.questown.integration.jobs.JobPhaseModifier;
+import ca.bradj.questown.integration.jobs.WarpTickEvent;
+import ca.bradj.questown.world.QTWorldAccess;
+import com.google.common.collect.ImmutableList;
+import net.minecraft.core.BlockPos;
+
+import java.util.Collection;
+import java.util.function.Supplier;
+
+import static ca.bradj.questown.jobs.declarative.PrePostHooks.processMulti;
+
+public class WarpTickHook {
+
+    public static <X> X run(
+            Collection<String> rules,
+            QTWorldAccess world,
+            X town,
+            long currentTick,
+            long tickDelta,
+            Supplier<Collection<BlockPos>> workBlocks
+    ) {
+        ImmutableList<JobPhaseModifier> appliers =
+                SpecialRulesRegistry.getRuleAppliers(rules);
+        WarpTickEvent event = new WarpTickEvent(
+                world, currentTick, tickDelta, workBlocks
+        );
+        X result = processMulti(
+                town, appliers,
+                (t, a) -> a.onWarpTick(t, event)
+        );
+        return result != null ? result : town;
+    }
+}

--- a/src/main/java/ca/bradj/questown/jobs/special/GrowCropsWarpRule.java
+++ b/src/main/java/ca/bradj/questown/jobs/special/GrowCropsWarpRule.java
@@ -1,0 +1,127 @@
+package ca.bradj.questown.jobs.special;
+
+import ca.bradj.questown.integration.jobs.JobPhaseModifier;
+import ca.bradj.questown.integration.jobs.WarpTickEvent;
+import ca.bradj.questown.world.QTWorldAccess;
+import net.minecraft.core.BlockPos;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.concurrent.ThreadLocalRandom;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
+
+/**
+ * Warp-interleaved hook that simulates crop growth during
+ * time warp. Uses vanilla random tick probability:
+ * 3/4096 chance per tick per block.
+ *
+ * Declared as a global rule in farmer job JSON files.
+ * Effects are proportional to {@code event.tickDelta()}.
+ *
+ * For large tick deltas (>= 1365), deterministic integer
+ * growths are applied per block. For small deltas, a
+ * population-based fallback ensures visible progress:
+ * the expected total growths across all eligible blocks
+ * are computed and distributed randomly, avoiding the
+ * problem where many independent low-probability rolls
+ * all miss.
+ * The "lore" for this is: Farmers tend the crops while the
+ * player is away from town, so they grow (slightly) better.
+ */
+public class GrowCropsWarpRule extends JobPhaseModifier implements QTNativeRule {
+
+    private static final int RANDOM_TICK_NUMERATOR = 3;
+    private static final int RANDOM_TICK_DENOMINATOR = 4096;
+
+    @Override
+    public <X> X onWarpTick(X town, WarpTickEvent event) {
+        QTWorldAccess world = event.world();
+        long tickDelta = event.tickDelta();
+        Collection<BlockPos> positions = event.workBlockPositions().get();
+
+        int deterministicGrowths = deterministicGrowthsPerBlock(tickDelta);
+        List<BlockPos> eligible = applyDeterministicGrowths(
+                world, positions, deterministicGrowths
+        );
+
+        if (deterministicGrowths == 0 && !eligible.isEmpty()) {
+            applyPopulationBasedGrowths(world, eligible, tickDelta);
+        }
+
+        return town;
+    }
+
+    private static int deterministicGrowthsPerBlock(long tickDelta) {
+        return (int) (tickDelta * RANDOM_TICK_NUMERATOR / RANDOM_TICK_DENOMINATOR);
+    }
+
+    private static List<BlockPos> applyDeterministicGrowths(
+            QTWorldAccess world,
+            Collection<BlockPos> positions,
+            int growths
+    ) {
+        List<BlockPos> eligible = new ArrayList<>();
+        for (BlockPos pos : positions) {
+            if (!isGrowableCrop(world, pos)) {
+                continue;
+            }
+            if (growths > 0) {
+                growBy(world, pos, growths);
+            } else {
+                eligible.add(pos);
+            }
+        }
+        return eligible;
+    }
+
+    private static void applyPopulationBasedGrowths(
+            QTWorldAccess world,
+            List<BlockPos> eligible,
+            long tickDelta
+    ) {
+        double perBlockChance = tickDelta * RANDOM_TICK_NUMERATOR / (double) RANDOM_TICK_DENOMINATOR;
+        double totalExpected = perBlockChance * eligible.size();
+        int guaranteed = (int) totalExpected;
+        double remainder = totalExpected - guaranteed;
+
+        eligible = world.getShuffledCopy(eligible);
+
+        for (int i = 0; i < guaranteed && i < eligible.size(); i++) {
+            growByOne(world, eligible.get(i));
+        }
+        if (remainder > 0 && guaranteed < eligible.size()
+                && ThreadLocalRandom.current().nextDouble() < remainder) {
+            growByOne(world, eligible.get(guaranteed));
+        }
+    }
+
+    private static boolean isGrowableCrop(QTWorldAccess world, BlockPos pos) {
+        OptionalInt age = world.getBlockIntProperty(pos, "age");
+        if (age.isEmpty()) {
+            return false;
+        }
+        OptionalInt maxAge = world.getMaxBlockIntProperty(pos, "age");
+        if (maxAge.isEmpty()) {
+            return false;
+        }
+        return age.getAsInt() < maxAge.getAsInt();
+    }
+
+    private static void growBy(QTWorldAccess world, BlockPos pos, int amount) {
+        OptionalInt age = world.getBlockIntProperty(pos, "age");
+        OptionalInt maxAge = world.getMaxBlockIntProperty(pos, "age");
+        if (age.isEmpty() || maxAge.isEmpty()) {
+            return;
+        }
+        int newAge = Math.min(age.getAsInt() + amount, maxAge.getAsInt());
+        if (newAge != age.getAsInt()) {
+            world.setBlockIntProperty(pos, "age", newAge);
+        }
+    }
+
+    private static void growByOne(QTWorldAccess world, BlockPos pos) {
+        growBy(world, pos, 1);
+    }
+}

--- a/src/main/java/ca/bradj/questown/jobs/special/SmeltFurnaceWarpRule.java
+++ b/src/main/java/ca/bradj/questown/jobs/special/SmeltFurnaceWarpRule.java
@@ -1,0 +1,26 @@
+package ca.bradj.questown.jobs.special;
+
+import ca.bradj.questown.QT;
+import ca.bradj.questown.integration.jobs.JobPhaseModifier;
+import ca.bradj.questown.integration.jobs.WarpTickEvent;
+import net.minecraft.core.BlockPos;
+
+import java.util.Collection;
+import ca.bradj.questown.integration.jobs.QTNativeRule;
+
+public class SmeltFurnaceWarpRule extends JobPhaseModifier implements QTNativeRule {
+
+    @Override
+    public <X> X onWarpTick(X town, WarpTickEvent event) {
+        Collection<BlockPos> positions = event.workBlockPositions().get();
+        int ticks = (int) event.tickDelta();
+        QT.FLAG_LOGGER.debug(
+                "SmeltFurnaceWarpRule: {} positions, {} tickDelta",
+                positions.size(), ticks
+        );
+        for (BlockPos pos : positions) {
+            event.world().advanceProcessing(pos, ticks);
+        }
+        return town;
+    }
+}

--- a/src/main/resources/data/questown/questown_job_archive/README.md
+++ b/src/main/resources/data/questown/questown_job_archive/README.md
@@ -1,0 +1,8 @@
+# Job Archive
+
+This folder may contain jobs which were relatively functional, but - for some reason - were not considered "stable 
+enough" to be released. Rather than risk losing them to version control churn, we put them here in the hope that they 
+might eventually be restored.
+
+Often, the reason for jobs to be in this folder is because they have insufficient support for the "time warp" mechanic, 
+which allows players to leave the villager and return later finding productivity has continued - via simulation.

--- a/src/main/resources/data/questown/questown_job_archive/arborist_cut_trees.json
+++ b/src/main/resources/data/questown/questown_job_archive/arborist_cut_trees.json
@@ -1,0 +1,39 @@
+{
+  "version": 2,
+  "id": "arborist/cut_trees",
+  "priority": "1000",
+  "parent": null,
+  "icon": "minecraft:oak_log",
+  "initial_request": "minecraft:oak_log",
+  "result": {
+    "type": "item",
+    "item": "minecraft:air"
+  },
+  "block": {
+    "id": "#minecraft:logs"
+  },
+  "room": "questown:special_quest.farm",
+  "work_states": [
+    {
+      "tools": "#questown:axes",
+      "work": 100
+    }
+  ],
+  "cooldown_ticks": 10,
+  "sound": {
+    "id": "minecraft:block.wood.hit",
+    "chance": "100",
+    "duration": 5
+  },
+  "special": [
+    {
+      "type": "global",
+      "rules": ["claim_workspot"]
+    },
+    {
+      "type": "core_state",
+      "state": "EXTRACTING_PRODUCT",
+      "rules": ["questown_vanilla:chop_down_tree"]
+    }
+  ]
+}

--- a/src/main/resources/data/questown/questown_job_archive/arborist_plant_tree.json
+++ b/src/main/resources/data/questown/questown_job_archive/arborist_plant_tree.json
@@ -1,0 +1,45 @@
+{
+  "version": 2,
+  "id": "arborist/plant_sapling",
+  "priority": "10000",
+  "parent": "arborist/cut_trees",
+  "icon": "minecraft:oak_sapling",
+  "initial_request": "minecraft:oak_log",
+  "result": {
+    "type": "item",
+    "item": "minecraft:air"
+  },
+  "block": {
+    "id": "#questown:tillables"
+  },
+  "room": "questown:special_quest.farm",
+  "work_states": [
+    {
+      "tools": "#minecraft:saplings"
+    },
+    {
+      "work": 3
+    },
+    {
+      "ingredients": "#minecraft:saplings",
+      "quantity": 1
+    }
+  ],
+  "cooldown_ticks": 10,
+  "sound": {
+    "id": "minecraft:item.shovel.place",
+    "chance": "100",
+    "duration": 5
+  },
+  "special": [
+    {
+      "type": "global",
+      "rules": ["questown_vanilla:check_tree_plantable","claim_workspot", "require_air_above"]
+    },
+    {
+      "type": "core_state",
+      "state": "EXTRACTING_PRODUCT",
+      "rules": ["questown:use_last_inserted_item_on_block"]
+    }
+  ]
+}

--- a/src/main/resources/data/questown/questown_job_archive/organizer_fetcher.json
+++ b/src/main/resources/data/questown/questown_job_archive/organizer_fetcher.json
@@ -1,0 +1,73 @@
+{
+  "version": 2,
+  "id": "organizer/fetch",
+  "priority": "4000",
+  "parent": null,
+  "icon": "questown:stock_request",
+  "initial_request": null,
+  "result": {
+    "type": "item",
+    "item": "minecraft:air",
+    "quantity": 1
+  },
+  "block": {
+    "id": "minecraft:chest"
+  },
+  "room": "questown:store_room",
+  "work_states": [
+    {
+      "tools": "questown:stock_request"
+    },
+    {
+      "work": 3
+    },
+    {
+      "comment": "this is only here to increase the max state",
+      "ingredients": "minecraft:diamond"
+    }
+  ],
+  "cooldown_ticks": 25,
+  "special": [
+    {
+      "type": "global",
+      "rules": [
+        "claim_workspot",
+        "require_two_free_spots",
+        "always_consider",
+        "workspot_from_held_item",
+        "render_last_item_in_off_hand",
+        "take_random_ingredient"
+      ]
+    },
+    {
+      "type": "processing_state",
+      "state": 0,
+      "rules": [
+        "workspot_from_held_item"
+      ]
+    },
+    {
+      "type": "processing_state",
+      "state": 1,
+      "rules": [
+        "tools_from_held_item",
+        "workspot_from_held_item"
+      ]
+    },
+    {
+      "type": "processing_state",
+      "state": 2,
+      "rules": [
+        "ingredients_from_held_item",
+        "workspot_from_held_item"
+      ]
+    },
+    {
+      "type": "processing_state",
+      "state": 2,
+      "rules": [
+        "add_item_to_container"
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/questown/questown_jobs/baker_stock_coal.json
+++ b/src/main/resources/data/questown/questown_jobs/baker_stock_coal.json
@@ -14,13 +14,13 @@
   "work_states": [
     {
       "tools": "#minecraft:coals",
-      "work": 10
+      "work": 1
     },
     {
       "ingredients": "#minecraft:coals"
     }
   ],
-  "cooldown_ticks": 5,
+  "cooldown_ticks": 50,
   "special": [
     {
       "type": "global",

--- a/src/main/resources/data/questown/questown_jobs/baker_stock_wheat.json
+++ b/src/main/resources/data/questown/questown_jobs/baker_stock_wheat.json
@@ -14,13 +14,13 @@
   "work_states": [
     {
       "tools": "minecraft:wheat",
-      "work": 10
+      "work": 1
     },
     {
       "ingredients": "minecraft:wheat"
     }
   ],
-  "cooldown_ticks": 5,
+  "cooldown_ticks": 50,
   "special": [
     {
       "type": "global",

--- a/src/main/resources/data/questown/questown_jobs/cook_extract.json
+++ b/src/main/resources/data/questown/questown_jobs/cook_extract.json
@@ -5,11 +5,8 @@
   "parent": null,
   "icon": "minecraft:cooked_beef",
   "initial_request": "minecraft:cooked_cod",
-  "note": "initial request is actually ignored due to 'always consider' in global rules",
   "result": {
-    "type": "item",
-    "item": "minecraft:air",
-    "quantity": 1
+    "type": "uses_special_rules"
   },
   "block": {
     "id": "minecraft:furnace",
@@ -32,7 +29,7 @@
   "special": [
     {
       "type": "global",
-      "rules": ["always_consider"]
+      "rules": ["always_consider", "furnace_smelt_warp"]
     },
     {
       "type": "core_state",

--- a/src/main/resources/data/questown/questown_jobs/cook_fish.json
+++ b/src/main/resources/data/questown/questown_jobs/cook_fish.json
@@ -6,9 +6,7 @@
   "icon": "minecraft:cod",
   "initial_request": "minecraft:cooked_cod",
   "result": {
-    "type": "item",
-    "item": "minecraft:air",
-    "quantity": 1
+    "type": "uses_special_rules"
   },
   "block": {
     "id": "minecraft:furnace",
@@ -33,7 +31,7 @@
   "special": [
     {
       "type": "global",
-      "rules": []
+      "rules": ["furnace_smelt_warp"]
     },
     {
       "type": "processing_state",

--- a/src/main/resources/data/questown/questown_jobs/cook_fuel.json
+++ b/src/main/resources/data/questown/questown_jobs/cook_fuel.json
@@ -6,9 +6,7 @@
   "icon": "minecraft:furnace",
   "initial_request": "#questown:villager_food",
   "result": {
-    "type": "item",
-    "item": "minecraft:air",
-    "quantity": 1
+    "type": "uses_special_rules"
   },
   "block": {
     "id": "minecraft:furnace",
@@ -35,7 +33,8 @@
     {
       "type": "global",
       "rules": [
-        "always_consider"
+        "always_consider",
+        "furnace_smelt_warp"
       ]
     },
     {

--- a/src/main/resources/data/questown/questown_jobs/cook_simple_furnace_food.json
+++ b/src/main/resources/data/questown/questown_jobs/cook_simple_furnace_food.json
@@ -6,9 +6,8 @@
   "icon": "minecraft:beef",
   "initial_request": "minecraft:cooked_beef",
   "result": {
-    "type": "item",
-    "item": "minecraft:air",
-    "quantity": 1
+    "type": "via_other_job",
+    "jobs": ["cook/extract"]
   },
   "block": {
     "id": "minecraft:furnace",
@@ -33,7 +32,7 @@
   "special": [
     {
       "type": "global",
-      "rules": []
+      "rules": ["furnace_smelt_warp"]
     },
     {
       "type": "processing_state",

--- a/src/main/resources/data/questown/questown_jobs/cook_stock_fuel.json
+++ b/src/main/resources/data/questown/questown_jobs/cook_stock_fuel.json
@@ -5,10 +5,9 @@
   "parent": "cook/fuel",
   "icon": "minecraft:chest",
   "initial_request": "#questown:villager_food",
-  "note": "initial request is actually ignored due to 'always consider' in global rules",
+  "note_warp": "Excluded from warp: stock jobs just move items between containers, which the warper handles automatically via simulateCollectSupplies",
   "result": {
-    "type": "item",
-    "item": "minecraft:air"
+    "type": "uses_special_rules"
   },
   "block": {
     "id": "#forge:chests"
@@ -27,7 +26,7 @@
   "special": [
     {
       "type": "global",
-      "rules": ["claim_workspot", "always_consider"]
+      "rules": ["claim_workspot", "always_consider", "exclude_from_warp"]
     },
     {
       "type": "processing_state",

--- a/src/main/resources/data/questown/questown_jobs/cook_stock_ingredients.json
+++ b/src/main/resources/data/questown/questown_jobs/cook_stock_ingredients.json
@@ -5,10 +5,9 @@
   "parent": "cook/extract",
   "icon": "minecraft:chest",
   "initial_request": "#questown:villager_food",
-  "note": "initial request is actually ignored due to 'always consider' in global rules",
+  "note_warp": "Excluded from warp: stock jobs just move items between containers, which the warper handles automatically via simulateCollectSupplies",
   "result": {
-    "type": "item",
-    "item": "minecraft:air"
+    "type": "uses_special_rules"
   },
   "block": {
     "id": "#forge:chests"
@@ -27,7 +26,7 @@
   "special": [
     {
       "type": "global",
-      "rules": ["claim_workspot", "always_consider"]
+      "rules": ["claim_workspot", "always_consider", "exclude_from_warp"]
     },
     {
       "type": "processing_state",

--- a/src/main/resources/data/questown/questown_jobs/crafter_planks.json
+++ b/src/main/resources/data/questown/questown_jobs/crafter_planks.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "id": "crafter/planks",
-  "priority": "1000",
+  "priority": "10000",
   "parent": "crafter/stick",
   "icon": "minecraft:oak_planks",
   "initial_request": "minecraft:oak_planks",
@@ -11,7 +11,7 @@
       "0"
     ],
     "fallback": "minecraft:oak_planks",
-    "quantity": 1
+    "quantity": 5
   },
   "block": "minecraft:crafting_table",
   "room": "questown:crafting_room",
@@ -24,9 +24,9 @@
       "work": 20
     }
   ],
-  "cooldown_ticks": 50,
+  "cooldown_ticks": 5,
   "sound": {
-    "id": "minecraft:block.wood.hit",
+    "id": "minecraft:item.axe.scrape",
     "chance": "100",
     "duration": 5
   }

--- a/src/main/resources/data/questown/questown_jobs/farmer_global_bone.json
+++ b/src/main/resources/data/questown/questown_jobs/farmer_global_bone.json
@@ -6,8 +6,7 @@
   "icon": "minecraft:bone_meal",
   "initial_request": "minecraft:bone_meal",
   "result": {
-    "type": "item",
-    "item": "minecraft:air"
+    "type": "uses_special_rules"
   },
   "block": {
     "id": "#minecraft:crops",
@@ -27,7 +26,7 @@
   "special": [
     {
       "type": "global",
-      "rules": ["claim_workspot", "shared_work_status"]
+      "rules": ["claim_workspot", "shared_work_status", "questown:crop_growth_warp"]
     },
     {
       "type": "core_state",

--- a/src/main/resources/data/questown/questown_jobs/farmer_global_compost.json
+++ b/src/main/resources/data/questown/questown_jobs/farmer_global_compost.json
@@ -6,8 +6,7 @@
   "icon": "minecraft:composter",
   "initial_request": "minecraft:bone_meal",
   "result": {
-    "type": "item",
-    "item": "minecraft:air"
+    "type": "uses_special_rules"
   },
   "block": {
     "id": "minecraft:composter"
@@ -22,7 +21,7 @@
   "special": [
     {
       "type": "global",
-      "rules": []
+      "rules": ["questown:crop_growth_warp"]
     },
     {
       "type": "core_state",

--- a/src/main/resources/data/questown/questown_jobs/farmer_global_till.json
+++ b/src/main/resources/data/questown/questown_jobs/farmer_global_till.json
@@ -6,8 +6,7 @@
   "icon": "minecraft:wooden_hoe",
   "initial_request": "minecraft:wheat",
   "result": {
-    "type": "item",
-    "item": "minecraft:air"
+    "type": "uses_special_rules"
   },
   "block": {
     "id": "#questown:tillables"
@@ -23,7 +22,7 @@
   "special": [
     {
       "type": "global",
-      "rules": ["require_air_above", "shared_work_status"]
+      "rules": ["require_air_above", "shared_work_status", "questown:crop_growth_warp"]
     },
     {
       "type": "core_state",

--- a/src/main/resources/data/questown/questown_jobs/farmer_global_weed.json
+++ b/src/main/resources/data/questown/questown_jobs/farmer_global_weed.json
@@ -6,8 +6,7 @@
   "icon": "minecraft:tall_grass",
   "initial_request": "minecraft:wheat_seeds",
   "result": {
-    "type": "item",
-    "item": "minecraft:air"
+    "type": "uses_special_rules"
   },
   "block": {
     "id": "#questown:weeds"
@@ -25,7 +24,8 @@
       "type": "global",
       "rules": [
         "claim_workspot",
-        "shared_work_status"
+        "shared_work_status",
+        "questown:crop_growth_warp"
       ]
     },
     {

--- a/src/main/resources/data/questown/questown_jobs/farmer_wheat_fill_seed_bin.json
+++ b/src/main/resources/data/questown/questown_jobs/farmer_wheat_fill_seed_bin.json
@@ -6,8 +6,7 @@
   "icon": "questown:seed_bin",
   "initial_request": "minecraft:wheat_seeds",
   "result": {
-    "type": "item",
-    "item": "minecraft:air"
+    "type": "uses_special_rules"
   },
   "block": {
     "id": "questown:seed_bin",
@@ -24,5 +23,10 @@
     }
   ],
   "cooldown_ticks": 1,
-  "special": []
+  "special": [
+    {
+      "type": "global",
+      "rules": ["questown:crop_growth_warp"]
+    }
+  ]
 }

--- a/src/main/resources/data/questown/questown_jobs/farmer_wheat_harvest.json
+++ b/src/main/resources/data/questown/questown_jobs/farmer_wheat_harvest.json
@@ -6,8 +6,7 @@
   "icon": "minecraft:wheat",
   "initial_request": "minecraft:wheat",
   "result": {
-    "type": "item",
-    "item": "minecraft:air"
+    "type": "uses_special_rules"
   },
   "block": {
     "id": "minecraft:wheat",
@@ -24,7 +23,7 @@
   "special": [
     {
       "type": "global",
-      "rules": ["claim_workspot", "shared_work_status"]
+      "rules": ["claim_workspot", "shared_work_status", "questown:crop_growth_warp"]
     },
     {
       "type": "core_state",

--- a/src/main/resources/data/questown/questown_jobs/farmer_wheat_plant.json
+++ b/src/main/resources/data/questown/questown_jobs/farmer_wheat_plant.json
@@ -6,8 +6,7 @@
   "icon": "minecraft:wheat_seeds",
   "initial_request": "minecraft:wheat",
   "result": {
-    "type": "item",
-    "item": "minecraft:air"
+    "type": "uses_special_rules"
   },
   "block": {
     "id": "minecraft:farmland"
@@ -26,7 +25,7 @@
   "special": [
     {
       "type": "global",
-      "rules": ["claim_workspot", "require_air_above"]
+      "rules": ["claim_workspot", "require_air_above", "questown:crop_growth_warp"]
     },
     {
       "type": "core_state",

--- a/src/main/resources/data/questown/questown_jobs/fisher_fish.json
+++ b/src/main/resources/data/questown/questown_jobs/fisher_fish.json
@@ -31,11 +31,13 @@
     {
       "type": "processing_state",
       "state": 0,
+      "note": "purely for visual effect",
       "rules": ["questown_vanilla:deploy_and_retract_fishing_hook"]
     },
     {
       "type": "core_state",
       "state": "EXTRACTING_PRODUCT",
+      "note": "purely for visual effect",
       "rules": ["questown_vanilla:deploy_and_retract_fishing_hook"]
     }
   ]

--- a/src/main/resources/data/questown/questown_jobs/gatherer_unmapped_rod_short.json
+++ b/src/main/resources/data/questown/questown_jobs/gatherer_unmapped_rod_short.json
@@ -21,7 +21,7 @@
       "work": 1
     },
     {
-      "time": 4000
+      "time": 2000
     }
   ],
   "cooldown_ticks": 0,

--- a/src/test/java/ca/bradj/questown/jobs/special/GrowCropsWarpRuleTest.java
+++ b/src/test/java/ca/bradj/questown/jobs/special/GrowCropsWarpRuleTest.java
@@ -1,0 +1,176 @@
+package ca.bradj.questown.jobs.special;
+
+import ca.bradj.questown.integration.jobs.WarpTickEvent;
+import ca.bradj.questown.world.TestWorldAccess;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+class GrowCropsWarpRuleTest {
+
+    private static final BlockPos POS_1 = new BlockPos(10, 64, 10);
+    private static final BlockPos POS_2 = new BlockPos(11, 64, 10);
+    private static final BlockPos POS_3 = new BlockPos(12, 64, 10);
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    private static WarpTickEvent makeEvent(
+            TestWorldAccess world,
+            long tickDelta,
+            List<BlockPos> positions
+    ) {
+        return new WarpTickEvent(world, 1000L, tickDelta, () -> positions);
+    }
+
+    // ========== Deterministic path (tickDelta >= 1366) ==========
+
+    @Test
+    void shouldGrowCrop_whenTickDeltaIsLarge() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withBlockProperty(POS_1, "age", 0, 7);
+
+        // 4096 * 3 / 4096 = 3 growths per block
+        WarpTickEvent event = makeEvent(world, 4096, List.of(POS_1));
+
+        GrowCropsWarpRule rule = new GrowCropsWarpRule();
+        Boolean result = rule.onWarpTick(true, event);
+
+        Assertions.assertEquals(3, world.getPropertyValue(POS_1, "age"));
+        Assertions.assertTrue(result);
+    }
+
+    @Test
+    void shouldCapAtMaxAge_whenGrowthExceedsMax() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withBlockProperty(POS_1, "age", 6, 7);
+
+        // 8192 * 3 / 4096 = 6 growths, but 6 + 6 = 12 → capped at 7
+        WarpTickEvent event = makeEvent(world, 8192, List.of(POS_1));
+
+        new GrowCropsWarpRule().onWarpTick(true, event);
+
+        Assertions.assertEquals(7, world.getPropertyValue(POS_1, "age"));
+    }
+
+    @Test
+    void shouldNotGrow_whenAlreadyAtMaxAge() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withBlockProperty(POS_1, "age", 7, 7);
+
+        WarpTickEvent event = makeEvent(world, 4096, List.of(POS_1));
+
+        new GrowCropsWarpRule().onWarpTick(true, event);
+
+        Assertions.assertEquals(7, world.getPropertyValue(POS_1, "age"));
+    }
+
+    @Test
+    void shouldNotGrow_whenBlockHasNoAgeProperty() {
+        TestWorldAccess world = new TestWorldAccess();
+
+        WarpTickEvent event = makeEvent(world, 4096, List.of(POS_1));
+
+        new GrowCropsWarpRule().onWarpTick(true, event);
+
+        Assertions.assertEquals(-1, world.getPropertyValue(POS_1, "age"));
+    }
+
+    @Test
+    void shouldGrowMultipleCrops_independently() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withBlockProperty(POS_1, "age", 0, 7)
+                .withBlockProperty(POS_2, "age", 4, 7)
+                .withBlockProperty(POS_3, "age", 6, 7);
+
+        // 4096 * 3 / 4096 = 3 growths per block
+        WarpTickEvent event = makeEvent(world, 4096, List.of(POS_1, POS_2, POS_3));
+
+        new GrowCropsWarpRule().onWarpTick(true, event);
+
+        Assertions.assertEquals(3, world.getPropertyValue(POS_1, "age"));
+        Assertions.assertEquals(7, world.getPropertyValue(POS_2, "age")); // 4+3=7
+        Assertions.assertEquals(7, world.getPropertyValue(POS_3, "age")); // 6+3=9 → capped at 7
+    }
+
+    // ========== Population-based path (tickDelta < 1366) ==========
+
+    @Test
+    void shouldGrowGuaranteedBlocks_whenPopulationIsLarge() {
+        BlockPos pos4 = new BlockPos(13, 64, 10);
+        BlockPos pos5 = new BlockPos(14, 64, 10);
+        BlockPos pos6 = new BlockPos(15, 64, 10);
+
+        TestWorldAccess world = new TestWorldAccess()
+                .withBlockProperty(POS_1, "age", 0, 7)
+                .withBlockProperty(POS_2, "age", 0, 7)
+                .withBlockProperty(POS_3, "age", 0, 7)
+                .withBlockProperty(pos4, "age", 0, 7)
+                .withBlockProperty(pos5, "age", 0, 7)
+                .withBlockProperty(pos6, "age", 0, 7);
+
+        // tickDelta=1000 → deterministicGrowths = 1000*3/4096 = 0
+        // perBlockChance = 1000*3/4096.0 ≈ 0.7324
+        // totalExpected = 0.7324 * 6 ≈ 4.39
+        // guaranteed = 4, remainder ≈ 0.39 (probabilistic extra)
+        List<BlockPos> allPositions = List.of(POS_1, POS_2, POS_3, pos4, pos5, pos6);
+        WarpTickEvent event = makeEvent(world, 1000, allPositions);
+
+        new GrowCropsWarpRule().onWarpTick(true, event);
+
+        int totalGrowth = 0;
+        for (BlockPos pos : allPositions) {
+            totalGrowth += world.getPropertyValue(pos, "age");
+        }
+        Assertions.assertTrue(totalGrowth >= 4,
+                "Expected at least 4 guaranteed growths, got " + totalGrowth);
+        Assertions.assertTrue(totalGrowth <= 5,
+                "Expected at most 5 total growths (4 guaranteed + 1 probabilistic), got " + totalGrowth);
+    }
+
+    // ========== Edge cases ==========
+
+    @Test
+    void shouldDoNothing_whenNoWorkBlocks() {
+        TestWorldAccess world = new TestWorldAccess();
+
+        WarpTickEvent event = makeEvent(world, 4096, Collections.emptyList());
+
+        new GrowCropsWarpRule().onWarpTick(true, event);
+    }
+
+    @Test
+    void shouldSkipNonGrowableBlocks() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withBlockProperty(POS_1, "age", 0, 7);
+        // POS_2 has no age property - not growable
+
+        WarpTickEvent event = makeEvent(world, 4096, List.of(POS_1, POS_2));
+
+        new GrowCropsWarpRule().onWarpTick(true, event);
+
+        Assertions.assertEquals(3, world.getPropertyValue(POS_1, "age"));
+        Assertions.assertEquals(-1, world.getPropertyValue(POS_2, "age"));
+    }
+
+    @Test
+    void shouldReturnTownUnchanged() {
+        TestWorldAccess world = new TestWorldAccess()
+                .withBlockProperty(POS_1, "age", 0, 7);
+
+        WarpTickEvent event = makeEvent(world, 4096, List.of(POS_1));
+
+        Boolean result = new GrowCropsWarpRule().onWarpTick(true, event);
+
+        Assertions.assertEquals(true, result);
+    }
+}


### PR DESCRIPTION
Warp hook infrastructure:
- JobPhaseModifier gains onWarpTick() and afterWarpRecovery()
- WarpTickEvent record: world, currentTick, tickDelta, workBlockPositions
- WarpTickHook: static utility resolving and calling onWarpTick()
- GrowCropsWarpRule: vanilla random tick crop growth (3/4096 probability)
- SmeltFurnaceWarpRule: furnace advancement during warp
- DeployFishingHookRule gains afterWarpRecovery (re-deploy cosmetic hook)

Rule registrations:
- QuestownSpecialRules: register crop_growth_warp, furnace_smelt_warp
- VanillaSpecialRules: comment clarifying fishing hook is cosmetic

Job JSON updates:
- All farmer jobs declare crop_growth_warp global rule
- All cook furnace jobs declare furnace_smelt_warp global rule
- Stock jobs marked exclude_from_warp
- Result types updated to uses_special_rules/via_other_job
- Baker/crafter balance tuning
- Arborist/organizer jobs archived to questown_job_archive/