### PR TITLE
Mix: campfire sleep, flag crafting, armorer, particles, worldgen

### DIFF
--- a/src/main/java/ca/bradj/questown/_vanilla/blocks/SaplingTesterBlock.java
+++ b/src/main/java/ca/bradj/questown/_vanilla/blocks/SaplingTesterBlock.java
@@ -5,6 +5,7 @@ import ca.bradj.questown._vanilla.CheckTreePlantable;
 import ca.bradj.questown.integration.minecraft.MCHeldItem;
 import ca.bradj.questown.jobs.JobBlockTestContext;
 import ca.bradj.questown.jobs.WorkLocation;
+import ca.bradj.questown.world.MinecraftWorldAccess;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
@@ -52,7 +53,7 @@ public class SaplingTesterBlock extends Block {
             return super.use(p_60503_, level, blockPos, player, p_60507_, p_60508_);
         }
         boolean allowed = new CheckTreePlantable().postJobBlockCheckPassed(new JobBlockTestContext(
-                sl, new WorkLocation.BlockInfo() {
+                new MinecraftWorldAccess(sl), new WorkLocation.BlockInfo() {
             @Override
             public BlockState state(BlockPos bp) {
                 return level.getBlockState(bp);

--- a/src/main/java/ca/bradj/questown/_vanilla/entities/EntitiesInit.java
+++ b/src/main/java/ca/bradj/questown/_vanilla/entities/EntitiesInit.java
@@ -13,7 +13,7 @@ import net.minecraftforge.registries.RegistryObject;
 public class EntitiesInit {
 
     public static final DeferredRegister<EntityType<?>> ENTITY_TYPES = DeferredRegister.create(
-            Compat.ENTITY_TYPES,
+            Compat.entityTypes(),
             Questown.MODID
     );
 

--- a/src/main/java/ca/bradj/questown/blocks/FishingStationBlock.java
+++ b/src/main/java/ca/bradj/questown/blocks/FishingStationBlock.java
@@ -107,11 +107,14 @@ public class FishingStationBlock extends RoomBlock {
         return InteractionResult.CONSUME;
     }
 
-    public static Vec3 getAttachPoint(
+    public static @Nullable Vec3 getAttachPoint(
             BlockPos p_60505_,
             ServerLevel sl
     ) {
         BlockState bs = sl.getBlockState(p_60505_);
+        if (!bs.hasProperty(FACING)) {
+            return null;
+        }
         Direction v = bs.getValue(FACING).getOpposite();
         Vec3 b = Vec3.atBottomCenterOf(p_60505_);
         Vec3 tip = Compat.relative(b.add(0, 1, 0), v, 0.5);

--- a/src/main/java/ca/bradj/questown/blocks/TownFlagBlock.java
+++ b/src/main/java/ca/bradj/questown/blocks/TownFlagBlock.java
@@ -10,14 +10,17 @@ import ca.bradj.questown.core.init.ModItemGroup;
 import ca.bradj.questown.core.init.TilesInit;
 import ca.bradj.questown.core.init.items.ItemsInit;
 import ca.bradj.questown.core.materials.WallType;
+import ca.bradj.questown.core.network.OpenFlagMenuMessage;
 import ca.bradj.questown.mc.Compat;
 import ca.bradj.questown.town.entity.TownFlagBlockEntity;
+import ca.bradj.questown.town.quests.Quest;
 import ca.bradj.questown.town.rewards.AddBatchOfQuestsForVisitorReward;
 import ca.bradj.questown.town.rewards.AddRandomUpgradeQuest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.tags.ItemTags;
@@ -32,6 +35,7 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.BaseEntityBlock;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityTicker;
@@ -60,7 +64,7 @@ public class TownFlagBlock extends BaseEntityBlock {
     public static final String ITEM_ID = "flag_base";
     public static final Item.Properties ITEM_PROPS = new Item.Properties().
             tab(ModItemGroup.QUESTOWN_GROUP);
-    public static final Property<Boolean> SLEEPING = BooleanProperty.create("sleeping");
+    public static final Property<Boolean> INACTIVE = BooleanProperty.create("inactive");
     private Map<Player, Long> informedPlayers = new HashMap<>();
 
     public TownFlagBlock() {
@@ -69,11 +73,11 @@ public class TownFlagBlock extends BaseEntityBlock {
                                          .strength(10.0F, 1200.0F)
                                          .noOcclusion()
         );
-        this.registerDefaultState(this.stateDefinition.any().setValue(SLEEPING, false));
+        this.registerDefaultState(this.stateDefinition.any().setValue(INACTIVE, false));
     }
 
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> p_51385_) {
-        p_51385_.add(SLEEPING);
+        p_51385_.add(INACTIVE);
     }
 
     public static String itemId(WallType wallType) {
@@ -162,9 +166,23 @@ public class TownFlagBlock extends BaseEntityBlock {
     ) {
         ItemStack itemInHand = player.getItemInHand(hand);
 
+        if (Ingredient.of(ItemTags.LOGS).test(itemInHand) && !entity.isFlagpoleBuilt()) {
+            if (hasActiveExoticWoodQuest(entity, itemInHand)) {
+                itemInHand.shrink(1);
+                BlockPos above = entity.getBlockPos().above();
+                level.setBlock(above, Blocks.OAK_FENCE.defaultBlockState(), 3);
+                level.setBlock(above.above(), Blocks.OAK_FENCE.defaultBlockState(), 3);
+                entity.setFlagpoleBuilt(true);
+                entity.setChanged();
+                return InteractionResult.CONSUME;
+            }
+        }
+
         if (itemInHand.getItem().equals(Items.DIRT)) {
-            entity.giveBonusFood(player);
-            return InteractionResult.CONSUME;
+            if (entity.giveBonusFood(player)) {
+                return InteractionResult.CONSUME;
+            }
+            return null; // already claimed — fall through to open the flag UI
         }
 
         if (itemInHand.getItem().equals(Items.DIAMOND)) {
@@ -216,9 +234,6 @@ public class TownFlagBlock extends BaseEntityBlock {
         }
         if (Ingredient.of(ItemTags.WOODEN_PRESSURE_PLATES).test(itemInHand)) {
             converted = ItemsInit.WELCOME_MAT_BLOCK.get().getDefaultInstance();
-        }
-        if (Ingredient.of(ItemTags.DOORS).test(itemInHand)) {
-            converted = ItemsInit.TOWN_DOOR.get().getDefaultInstance();
         }
         if (itemInHand.getItem().equals(ItemsInit.TOWN_DOOR.get())) {
             converted = ItemsInit.TOWN_DOOR.get().getDefaultInstance();
@@ -279,6 +294,38 @@ public class TownFlagBlock extends BaseEntityBlock {
             return InteractionResult.sidedSuccess(false);
         }
         return null;
+    }
+
+    private static boolean shouldPreSelectBopTab(TownFlagBlockEntity entity, ServerPlayer player) {
+        if (entity.getBlocksOfProgress() <= 0) {
+            return false;
+        }
+        // Pre-select BOP tab if the player hasn't viewed it yet
+        ResourceLocation advId = new ResourceLocation(Questown.MODID, "first_bop_view");
+        net.minecraft.advancements.Advancement adv = player.getServer().getAdvancements().getAdvancement(advId);
+        if (adv == null) {
+            return true;
+        }
+        return !player.getAdvancements().getOrStartProgress(adv).isDone();
+    }
+
+    private static boolean hasActiveExoticWoodQuest(TownFlagBlockEntity entity, ItemStack itemInHand) {
+        ResourceLocation heldItemId = Compat.getItemId(itemInHand.getItem());
+        for (Quest<ResourceLocation, ?> q : entity.getAllQuests()) {
+            if (q.getType() != Quest.QuestType.ITEM) {
+                continue;
+            }
+            if (q.isComplete()) {
+                continue;
+            }
+            if (q.getFlavorText() == null || !q.getFlavorText().contains("flagpole")) {
+                continue;
+            }
+            if (heldItemId.equals(q.getWantedId())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static void StoreParentOnNBT(
@@ -388,7 +435,16 @@ public class TownFlagBlock extends BaseEntityBlock {
         }
 
         if (oEntity.get().isInitialized()) {
-            oEntity.get().getVillagerHandle().showMultiStatusUI((ServerPlayer) player);
+            if (shouldPreSelectBopTab(entity, (ServerPlayer) player)) {
+                entity.menus.showUI(
+                        (ServerPlayer) player,
+                        OpenFlagMenuMessage.BOP,
+                        entity.getInfo(),
+                        entity.getBlocksOfProgress()
+                );
+            } else {
+                oEntity.get().getVillagerHandle().showMultiStatusUI((ServerPlayer) player);
+            }
         } else {
             if (!oEntity.get().isInitializing()) {
                 oEntity.get().initializeFreshFlag(true);

--- a/src/main/java/ca/bradj/questown/blocks/TownFlagSubBlocks.java
+++ b/src/main/java/ca/bradj/questown/blocks/TownFlagSubBlocks.java
@@ -39,7 +39,7 @@ public final class TownFlagSubBlocks {
         BlockEntity en = sl.getBlockEntity(blockPos);
         if ((en instanceof TownFlagBlockEntity)) {
             BlockState state = sl.getBlockState(blockPos);
-            sl.setBlockAndUpdate(blockPos, state.setValue(TownFlagBlock.SLEEPING, false));
+            sl.setBlockAndUpdate(blockPos, state.setValue(TownFlagBlock.INACTIVE, false));
         }
         if (!pending.isEmpty()) {
             BlockPos popped = pending.pop();
@@ -76,7 +76,11 @@ public final class TownFlagSubBlocks {
             ServerLevel sl,
             BlockPos pos
     ) {
-        if (sl.getBlockState(flagPos).getValue(TownFlagBlock.SLEEPING)) {
+        BlockState flagState = sl.getBlockState(flagPos);
+        if (!flagState.hasProperty(TownFlagBlock.INACTIVE)) {
+            return;
+        }
+        if (flagState.getValue(TownFlagBlock.INACTIVE)) {
             ticksWithoutParent.put(pos, 0);
             return;
         }

--- a/src/main/java/ca/bradj/questown/core/init/MenuTypesInit.java
+++ b/src/main/java/ca/bradj/questown/core/init/MenuTypesInit.java
@@ -59,6 +59,9 @@ public class MenuTypesInit {
     public static RegistryObject<MenuType<TownBlockofProgressMenu>> TOWN_BLOCKS_OF_PROGRESS = MENUS.register(
             "town_blocks_of_progress", () -> IForgeMenuType.create(TownBlockofProgressMenu::ForClientSide)
     );
+    public static RegistryObject<MenuType<FlagCraftingMenu>> FLAG_CRAFTING = MENUS.register(
+            "flag_crafting", () -> IForgeMenuType.create(FlagCraftingMenu::ForClientSide)
+    );
 
     public static void register(IEventBus eventBus) {
         MENUS.register(eventBus);

--- a/src/main/java/ca/bradj/questown/core/init/TagsInit.java
+++ b/src/main/java/ca/bradj/questown/core/init/TagsInit.java
@@ -25,6 +25,7 @@ public class TagsInit {
         public static final TagKey<Item> COMPOSTABLE = createTag("compostable");
         public static final TagKey<Item> JOB_BOARD_INPUTS = createTag("job_board_inputs");
         public static final TagKey<Item> SOUP_POTS = createTag("soup_pots");
+        public static final TagKey<Item> ARMOR_MATERIALS = createTag("armor_materials");
 
         // BLOCKS
         public static final TagKey<Block> TILLABLES = createBlockTag("tillables");

--- a/src/main/java/ca/bradj/questown/core/network/FlagCraftMessage.java
+++ b/src/main/java/ca/bradj/questown/core/network/FlagCraftMessage.java
@@ -1,0 +1,66 @@
+package ca.bradj.questown.core.network;
+
+import ca.bradj.questown.QT;
+import ca.bradj.questown.core.init.items.ItemsInit;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+public record FlagCraftMessage(BlockPos flagPos, int recipeIndex) {
+
+    public static void encode(FlagCraftMessage msg, FriendlyByteBuf buffer) {
+        buffer.writeBlockPos(msg.flagPos);
+        buffer.writeInt(msg.recipeIndex);
+    }
+
+    public static FlagCraftMessage decode(FriendlyByteBuf buffer) {
+        return new FlagCraftMessage(buffer.readBlockPos(), buffer.readInt());
+    }
+
+    public void handle(Supplier<NetworkEvent.Context> ctx) {
+        ctx.get().enqueueWork(() -> {
+            ServerPlayer sender = ctx.get().getSender();
+            if (sender == null) {
+                return;
+            }
+            switch (recipeIndex) {
+                case 0 -> craftWand(sender);
+                case 1 -> craftWelcomeMat(sender);
+                default -> QT.GUI_LOGGER.error("Unknown flag craft recipe index: {}", recipeIndex);
+            }
+        });
+        ctx.get().setPacketHandled(true);
+    }
+
+    private void craftWand(ServerPlayer player) {
+        if (!consumeItem(player, Items.STICK)) {
+            return;
+        }
+        player.getInventory().add(new ItemStack(ItemsInit.TOWN_WAND.get()));
+    }
+
+    private void craftWelcomeMat(ServerPlayer player) {
+        if (!consumeItem(player, Items.OAK_PRESSURE_PLATE)) {
+            return;
+        }
+        player.getInventory().add(new ItemStack(ItemsInit.WELCOME_MAT_BLOCK.get()));
+    }
+
+    private boolean consumeItem(ServerPlayer player, Item required) {
+        for (int i = 0; i < player.getInventory().getContainerSize(); i++) {
+            ItemStack stack = player.getInventory().getItem(i);
+            if (stack.is(required)) {
+                stack.shrink(1);
+                return true;
+            }
+        }
+        QT.GUI_LOGGER.warn("Player {} tried to flag-craft but lacks the input item", player.getName().getString());
+        return false;
+    }
+}

--- a/src/main/java/ca/bradj/questown/gui/FlagCraftingMenu.java
+++ b/src/main/java/ca/bradj/questown/gui/FlagCraftingMenu.java
@@ -1,0 +1,50 @@
+package ca.bradj.questown.gui;
+
+import ca.bradj.questown.core.init.MenuTypesInit;
+import ca.bradj.questown.core.network.OpenFlagMenuMessage;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Collection;
+
+public class FlagCraftingMenu extends AbstractContainerMenu implements FlagTabsEmbedding {
+    private static final Collection<String> ENABLED_TABS = FlagTabs.allExcept(OpenFlagMenuMessage.CRAFTING);
+    private final FlagInfo flagInfo;
+
+    public static FlagCraftingMenu ForClientSide(
+            int windowId,
+            Inventory inv,
+            FriendlyByteBuf buf
+    ) {
+        FlagMenus menus = FlagMenus.fromNetwork(windowId, inv.player, buf);
+        return menus.craftingMenu;
+    }
+
+    public FlagCraftingMenu(int windowId, FlagInfo flagInfo) {
+        super(MenuTypesInit.FLAG_CRAFTING.get(), windowId);
+        this.flagInfo = flagInfo;
+    }
+
+    @Override
+    public ItemStack quickMoveStack(Player player, int i) {
+        return ItemStack.EMPTY;
+    }
+
+    @Override
+    public boolean stillValid(Player player) {
+        return true;
+    }
+
+    @Override
+    public Collection<String> getEnabledTabs() {
+        return ENABLED_TABS;
+    }
+
+    @Override
+    public FlagInfo getFlagInfo() {
+        return flagInfo;
+    }
+}

--- a/src/main/java/ca/bradj/questown/gui/FlagCraftingScreen.java
+++ b/src/main/java/ca/bradj/questown/gui/FlagCraftingScreen.java
@@ -1,0 +1,121 @@
+package ca.bradj.questown.gui;
+
+import ca.bradj.questown.core.Coordinate;
+import ca.bradj.questown.core.init.items.ItemsInit;
+import ca.bradj.questown.core.network.FlagCraftMessage;
+import ca.bradj.questown.core.network.QuestownNetwork;
+import ca.bradj.questown.mc.Compat;
+import ca.bradj.questown.mc.JEI;
+import com.google.common.collect.ImmutableList;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.client.renderer.Rect2i;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
+import java.util.List;
+
+public class FlagCraftingScreen extends AbstractContainerScreen<FlagCraftingMenu> {
+    private static final int backgroundWidth = 176;
+    private static final int backgroundHeight = 166;
+    private final FlagTabs tabs;
+    private final JEI.NineNine background;
+    private final BlockPos flagPos;
+
+    public FlagCraftingScreen(
+            FlagCraftingMenu menu,
+            Inventory playerInv,
+            Component title
+    ) {
+        super(menu, playerInv, title);
+        super.imageWidth = 256;
+        super.imageHeight = 220;
+        this.background = JEI.getRecipeBackground();
+        this.tabs = FlagTabs.forMenu(menu);
+        this.flagPos = menu.getFlagInfo().flagPos();
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        int bgX = (this.width - backgroundWidth) / 2;
+        int bgY = (this.height - backgroundHeight) / 2;
+
+        this.addRenderableWidget(new Button(
+                bgX + 100, bgY + 30, 60, 20,
+                Compat.translatable("menu.flag_crafting.craft"),
+                btn -> QuestownNetwork.CHANNEL.sendToServer(new FlagCraftMessage(flagPos, 0))
+        ));
+        this.addRenderableWidget(new Button(
+                bgX + 100, bgY + 70, 60, 20,
+                Compat.translatable("menu.flag_crafting.craft"),
+                btn -> QuestownNetwork.CHANNEL.sendToServer(new FlagCraftMessage(flagPos, 1))
+        ));
+    }
+
+    @Override
+    protected void renderLabels(PoseStack stack, int mouseX, int mouseY) {
+    }
+
+    @Override
+    public void render(PoseStack poseStack, int mouseX, int mouseY, float partialTicks) {
+        this.renderBackground(poseStack);
+        super.render(poseStack, mouseX, mouseY, partialTicks);
+
+        int bgX = (this.width - backgroundWidth) / 2;
+        int bgY = (this.height - backgroundHeight) / 2;
+
+        Coordinate topLeft = new Coordinate(bgX + 12, bgY + 10);
+        int tWidth = backgroundWidth - 16;
+        Compat.drawDarkTextWrap(font, poseStack, topLeft, tWidth, Compat.translatable("menu.flag_crafting.title"));
+
+        renderRecipeRow(poseStack, bgX, bgY + 28, Items.STICK.getDefaultInstance(),
+                new ItemStack(ItemsInit.TOWN_WAND.get()), "menu.flag_crafting.wand_desc");
+        renderRecipeRow(poseStack, bgX, bgY + 68, Items.OAK_PRESSURE_PLATE.getDefaultInstance(),
+                new ItemStack(ItemsInit.WELCOME_MAT_BLOCK.get()), "menu.flag_crafting.mat_desc");
+    }
+
+    private void renderRecipeRow(PoseStack poseStack, int x, int y, ItemStack input, ItemStack output, String descKey) {
+        itemRenderer.renderAndDecorateItem(input, x + 12, y + 2);
+        font.draw(poseStack, "\u2192", x + 36, y + 6, 0x404040);
+        itemRenderer.renderAndDecorateItem(output, x + 50, y + 2);
+        Compat.drawDarkTextWrap(font, poseStack, new Coordinate(x + 12, y + 22), backgroundWidth - 120,
+                Compat.translatable(descKey));
+    }
+
+    @Override
+    protected void renderBg(PoseStack stack, float partialTicks, int mouseX, int mouseY) {
+        int bgX = (this.width - backgroundWidth) / 2;
+        int bgY = (this.height - backgroundHeight) / 2;
+        this.background.draw(stack, bgX, bgY, backgroundWidth, backgroundHeight);
+        this.tabs.draw(new RenderContext(itemRenderer, stack), bgX, bgY);
+    }
+
+    @Override
+    public boolean isPauseScreen() {
+        return false;
+    }
+
+    public List<Rect2i> getExtraAreas() {
+        int x = (this.width - backgroundWidth) / 2;
+        int y = (this.height - backgroundHeight) / 2;
+        return ImmutableList.of(new Rect2i(x, y, backgroundWidth, backgroundHeight));
+    }
+
+    @Override
+    public boolean isMouseOver(double mouseX, double mouseY) {
+        return true;
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        int x = (this.width - backgroundWidth) / 2;
+        int y = (this.height - backgroundHeight) / 2;
+        this.tabs.mouseClicked(x, y, mouseX, mouseY);
+        return super.mouseClicked(mouseX, mouseY, button);
+    }
+}

--- a/src/main/java/ca/bradj/questown/items/CampfireSleepClientEvents.java
+++ b/src/main/java/ca/bradj/questown/items/CampfireSleepClientEvents.java
@@ -1,0 +1,51 @@
+package ca.bradj.questown.items;
+
+import ca.bradj.questown.Questown;
+import ca.bradj.questown.gui.ClientAccess;
+import ca.bradj.questown.mc.Compat;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(modid = Questown.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
+public final class CampfireSleepClientEvents {
+
+    private static int hintCooldown = 0;
+
+    @SubscribeEvent
+    public static void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) {
+            return;
+        }
+        if (hintCooldown-- > 0) {
+            return;
+        }
+
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.player == null || mc.level == null) {
+            return;
+        }
+        if (!(mc.player.getMainHandItem().getItem() instanceof TownWand)) {
+            return;
+        }
+
+        HitResult hit = mc.hitResult;
+        if (!(hit instanceof BlockHitResult bhr)) {
+            return;
+        }
+        if (!mc.level.getBlockState(bhr.getBlockPos()).is(Blocks.CAMPFIRE)) {
+            return;
+        }
+
+        String key = mc.level.isNight()
+                ? "message.wand.campfire.sleep_hint"
+                : "message.wand.campfire.day_hint";
+        ClientAccess.showHint(Compat.translatable(key));
+        hintCooldown = 40;
+    }
+}

--- a/src/main/java/ca/bradj/questown/items/CampfireSleepForgeEvents.java
+++ b/src/main/java/ca/bradj/questown/items/CampfireSleepForgeEvents.java
@@ -1,0 +1,33 @@
+package ca.bradj.questown.items;
+
+import ca.bradj.questown.Questown;
+import ca.bradj.questown.core.advancements.TutorialTrigger;
+import ca.bradj.questown.core.init.AdvancementsInit;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraftforge.event.entity.player.PlayerWakeUpEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(modid = Questown.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+public final class CampfireSleepForgeEvents {
+
+    @SubscribeEvent
+    public static void onWakeUp(PlayerWakeUpEvent event) {
+        if (!(event.getEntity() instanceof ServerPlayer sp)) {
+            return;
+        }
+        if (!CampfireSleepHandler.isCampfireSleeper(sp.getUUID())) {
+            return;
+        }
+        CampfireSleepHandler.onWake(sp);
+        applyGrogginess(sp);
+        AdvancementsInit.TUTORIAL_TRIGGER.trigger(sp, TutorialTrigger.Triggers.FirstCampfireSleep);
+    }
+
+    private static void applyGrogginess(ServerPlayer player) {
+        player.addEffect(new MobEffectInstance(MobEffects.DIG_SLOWDOWN, 6000, 0, false, false));
+        player.addEffect(new MobEffectInstance(MobEffects.WEAKNESS, 6000, 0, false, false));
+    }
+}

--- a/src/main/java/ca/bradj/questown/items/CampfireSleepHandler.java
+++ b/src/main/java/ca/bradj/questown/items/CampfireSleepHandler.java
@@ -1,0 +1,142 @@
+package ca.bradj.questown.items;
+
+import ca.bradj.questown.logic.TownCycle;
+import ca.bradj.questown.mc.Util;
+import ca.bradj.questown.town.entity.TownFlagBlockEntity;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.BedBlock;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BedPart;
+import net.minecraft.world.level.material.Material;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.server.level.ServerPlayer;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class CampfireSleepHandler {
+
+    private static final Set<UUID> campfireSleepers = Collections.synchronizedSet(new HashSet<>());
+    private static final Map<UUID, BlockPos> tempBedPositions = new ConcurrentHashMap<>();
+    private static final Map<UUID, Direction> tempBedFacings = new ConcurrentHashMap<>();
+
+    public static void beginCampfireSleep(
+            ServerPlayer player,
+            Level level,
+            BlockPos campfirePos,
+            TownFlagBlockEntity parent
+    ) {
+        boolean campfireRegistered = TownCycle.findCampfire(parent.getBlockPos(), level)
+                                              .filter(campfirePos::equals)
+                                              .isPresent();
+        if (!campfireRegistered) {
+            Util.onScreenText(() -> player, "message.wand.campfire.not_registered");
+            return;
+        }
+
+        BlockPos headPos = findSafeSleepPosition(level, campfirePos);
+        if (headPos == null) {
+            Util.onScreenText(() -> player, "message.wand.campfire.no_safe_position");
+            return;
+        }
+
+        Direction facing = findBedFacing(level, headPos);
+        if (facing == null) {
+            Util.onScreenText(() -> player, "message.wand.campfire.no_safe_position");
+            return;
+        }
+
+        UUID uuid = player.getUUID();
+        campfireSleepers.add(uuid);
+        tempBedPositions.put(uuid, headPos);
+        tempBedFacings.put(uuid, facing);
+
+        placeTempBed(level, headPos, facing);
+
+        player.startSleepInBed(headPos).ifLeft(problem -> {
+            if (problem != null) {
+                player.displayClientMessage(problem.getMessage(), true);
+            }
+            campfireSleepers.remove(uuid);
+            tempBedPositions.remove(uuid);
+            tempBedFacings.remove(uuid);
+            removeTempBed(level, headPos, facing);
+        });
+    }
+
+    static @Nullable BlockPos findSafeSleepPosition(Level level, BlockPos campfirePos) {
+        for (Direction dir : Direction.Plane.HORIZONTAL) {
+            BlockPos candidate = campfirePos.relative(dir);
+            BlockPos below = candidate.below();
+            if (!level.getBlockState(below).isFaceSturdy(level, below, Direction.UP)) {
+                continue;
+            }
+            if (!isClearForSleep(level, candidate) || !isClearForSleep(level, candidate.above())) {
+                continue;
+            }
+            return candidate;
+        }
+        return null;
+    }
+
+    private static boolean isClearForSleep(Level level, BlockPos pos) {
+        BlockState state = level.getBlockState(pos);
+        if (!level.isUnobstructed(state, pos, CollisionContext.empty())) {
+            return false;
+        }
+        Material mat = state.getMaterial();
+        return !mat.isLiquid() && mat != Material.FIRE;
+    }
+
+    private static @Nullable Direction findBedFacing(Level level, BlockPos headPos) {
+        for (Direction dir : Direction.Plane.HORIZONTAL) {
+            BlockPos footPos = headPos.relative(dir.getOpposite());
+            if (level.getBlockState(footPos).getMaterial().isReplaceable()) {
+                return dir;
+            }
+        }
+        return null;
+    }
+
+    private static void placeTempBed(Level level, BlockPos headPos, Direction facing) {
+        BlockPos footPos = headPos.relative(facing.getOpposite());
+        BlockState headState = Blocks.RED_BED.defaultBlockState()
+                                             .setValue(BedBlock.FACING, facing)
+                                             .setValue(BedBlock.PART, BedPart.HEAD)
+                                             .setValue(BedBlock.OCCUPIED, false);
+        BlockState footState = Blocks.RED_BED.defaultBlockState()
+                                             .setValue(BedBlock.FACING, facing)
+                                             .setValue(BedBlock.PART, BedPart.FOOT)
+                                             .setValue(BedBlock.OCCUPIED, false);
+        level.setBlock(headPos, headState, 3);
+        level.setBlock(footPos, footState, 3);
+    }
+
+    private static void removeTempBed(Level level, BlockPos headPos, Direction facing) {
+        BlockPos footPos = headPos.relative(facing.getOpposite());
+        level.setBlock(headPos, Blocks.AIR.defaultBlockState(), 3);
+        level.setBlock(footPos, Blocks.AIR.defaultBlockState(), 3);
+    }
+
+    public static boolean isCampfireSleeper(UUID uuid) {
+        return campfireSleepers.contains(uuid);
+    }
+
+    public static void onWake(ServerPlayer player) {
+        UUID uuid = player.getUUID();
+        campfireSleepers.remove(uuid);
+        BlockPos headPos = tempBedPositions.remove(uuid);
+        Direction facing = tempBedFacings.remove(uuid);
+        if (headPos != null && facing != null) {
+            removeTempBed(player.level, headPos, facing);
+        }
+    }
+}

--- a/src/main/java/ca/bradj/questown/items/TownWand.java
+++ b/src/main/java/ca/bradj/questown/items/TownWand.java
@@ -21,6 +21,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.DoorBlock;
 import net.minecraft.world.level.block.FenceGateBlock;
 import net.minecraft.world.level.block.state.BlockState;
@@ -63,6 +64,12 @@ public class TownWand extends Item {
             ItemStack itemInHand
     ) {
         TownFlagBlockEntity parent = TownFlagBlock.GetParentFromNBT(level, itemInHand);
+
+        if (level.getBlockState(clickedPos).is(Blocks.CAMPFIRE)) {
+            CampfireSleepHandler.beginCampfireSleep(player.get(), level, clickedPos, parent);
+            return;
+        }
+
         for (ClickHandler handler : handlers) {
             if (handler.handle(level, clickedPos, parent)) {
                 return;
@@ -79,6 +86,9 @@ public class TownWand extends Item {
             return InteractionResult.CONSUME;
         }
         ServerLevel level = (ServerLevel) p_41427_.getLevel();
+        if (level.getBlockState(p_41427_.getClickedPos()).is(Blocks.CAMPFIRE)) {
+            return InteractionResult.CONSUME;
+        }
         for (ClickHandler handler : handlers) {
             if (handler.getEffectivePosition(level, p_41427_.getClickedPos()) != null) {
                 return InteractionResult.CONSUME;

--- a/src/main/java/ca/bradj/questown/mobs/visitor/VisitorMobEntity.java
+++ b/src/main/java/ca/bradj/questown/mobs/visitor/VisitorMobEntity.java
@@ -22,7 +22,7 @@ import ca.bradj.questown.mc.Util;
 import ca.bradj.questown.town.PoseInPlace;
 import ca.bradj.questown.town.VillagerStatsData;
 import ca.bradj.questown.town.entity.TownFlagBlockEntity;
-import ca.bradj.questown.town.entity.TownVillagers;
+import ca.bradj.questown.town.entity.TownVillagerMobs;
 import ca.bradj.questown.town.interfaces.TownInterface;
 import ca.bradj.questown.town.quests.MCQuest;
 import ca.bradj.questown.town.quests.MCReward;
@@ -455,6 +455,8 @@ public class VisitorMobEntity extends PathfinderMob implements VillagerStats {
         villagerTick(sl);
         long end = System.currentTimeMillis();
 
+        spawnIdleParticlesIfNeeded(sl);
+
         tickTimes.add((int) (end - start));
 
         Integer rate = Compat.configGet(Config.TICK_SAMPLING_RATE).get();
@@ -469,6 +471,20 @@ public class VisitorMobEntity extends PathfinderMob implements VillagerStats {
         }
     }
 
+
+    private void spawnIdleParticlesIfNeeded(ServerLevel sl) {
+        if (sl.getGameTime() % 40 != 0) {
+            return;
+        }
+        IStatus<?> s = getStatusForServer();
+        if (s == null) {
+            return;
+        }
+        if (!s.name().equals("NO_SUPPLIES")) {
+            return;
+        }
+        addParticlesAroundSelf(sl, ParticleTypes.ANGRY_VILLAGER);
+    }
 
     protected void addParticlesAroundSelf(ServerLevel sl, ParticleOptions p_35288_) {
         double d0 = this.random.nextGaussian() * 0.02D;
@@ -901,7 +917,7 @@ public class VisitorMobEntity extends PathfinderMob implements VillagerStats {
                 // FIXME: This can fail with "Town has not been initialized on TownVillagerHandle"
                 //  This should either be retried multiple times, or this initialization
                 //  should be handled by the town flag
-                TownVillagers.assumeStateFromTown(flag, this);
+                TownVillagerMobs.assumeStateFromTown(flag, this);
                 this.initBrain();
             }
         }

--- a/src/main/java/ca/bradj/questown/town/AbstractTownFlagTicker.java
+++ b/src/main/java/ca/bradj/questown/town/AbstractTownFlagTicker.java
@@ -41,7 +41,7 @@ public abstract class AbstractTownFlagTicker<TICK_DATA, VILLAGERS> {
             if (alreadyStopped) {
                 return;
             }
-            storeSleepingState(data);
+            storeInactiveState(data);
         }
 
         long start = System.currentTimeMillis();
@@ -191,7 +191,7 @@ public abstract class AbstractTownFlagTicker<TICK_DATA, VILLAGERS> {
 
     protected abstract void notifySubBlocksOfTick(TICK_DATA data);
 
-    protected abstract void storeSleepingState(TICK_DATA data);
+    protected abstract void storeInactiveState(TICK_DATA data);
 
     protected abstract boolean allPlayersLeftArea(
             TICK_DATA data,

--- a/src/main/java/ca/bradj/questown/town/entity/SimpleVillagerHandle.java
+++ b/src/main/java/ca/bradj/questown/town/entity/SimpleVillagerHandle.java
@@ -106,6 +106,7 @@ public final class SimpleVillagerHandle<DATA, ENTITY> {
     ) {
         this.delegator = del;
         this.configs = config;
+        this.hungerEnabled = config.hungerEnabled;
     }
 
     public void initialize(

--- a/src/main/java/ca/bradj/questown/town/entity/TownFlagBOPItemHandler.java
+++ b/src/main/java/ca/bradj/questown/town/entity/TownFlagBOPItemHandler.java
@@ -71,6 +71,7 @@ public class TownFlagBOPItemHandler implements IItemHandler {
         if (!simulate) {
             town.bopCount++;
             QT.FLAG_LOGGER.debug("Flag now contains {} BOPs", town.bopCount);
+            town.messages.broadcastMessage("messages.bop.earned");
         }
         return itemStack;
     }

--- a/src/main/java/ca/bradj/questown/town/entity/TownFlagInitializationImpl.java
+++ b/src/main/java/ca/bradj/questown/town/entity/TownFlagInitializationImpl.java
@@ -83,12 +83,24 @@ public class TownFlagInitializationImpl implements TownFlagInitialization {
     public CompoundTag serializeBOP() {
         CompoundTag t = new CompoundTag();
         t.putInt("count", flag.bopCount);
+        t.putBoolean("tutorial_bop_granted", flag.tutorialBopGranted);
+        t.putBoolean("flagpole_built", flag.isFlagpoleBuilt());
+        t.putInt("completed_procedural_batches", flag.completedProceduralBatches);
         return t;
     }
 
     @Override
     public void initializeBOP(CompoundTag tag) {
         flag.bopCount = tag.getInt("count");
+        if (tag.contains("tutorial_bop_granted")) {
+            flag.tutorialBopGranted = tag.getBoolean("tutorial_bop_granted");
+        }
+        if (tag.contains("flagpole_built")) {
+            flag.setFlagpoleBuilt(tag.getBoolean("flagpole_built"));
+        }
+        if (tag.contains("completed_procedural_batches")) {
+            flag.completedProceduralBatches = tag.getInt("completed_procedural_batches");
+        }
     }
 
     @Override

--- a/src/main/java/ca/bradj/questown/town/entity/TownFlagTicker.java
+++ b/src/main/java/ca/bradj/questown/town/entity/TownFlagTicker.java
@@ -20,6 +20,7 @@ import ca.bradj.questown.town.quests.Reward;
 import ca.bradj.roomrecipes.serialization.MCRoom;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.player.Player;
@@ -135,6 +136,7 @@ public class TownFlagTicker extends AbstractTownFlagTicker<TownFlagTicker.TickDa
         e.possibleWork.invalidate();
         e.quests.processItemQuests(TownContainers.getAllStacks(e, e.getServerLevel()));
         e.quests.processJobChanges(e.getVillagerHandle().getVillagerJobs());
+        e.quests.processConcurrentJobs(e.getVillagerHandle().getVillagerJobs());
     }
 
     @Override
@@ -180,9 +182,9 @@ public class TownFlagTicker extends AbstractTownFlagTicker<TownFlagTicker.TickDa
     }
 
     @Override
-    protected void storeSleepingState(TickData tickData) {
+    protected void storeInactiveState(TickData tickData) {
         BlockState bs = tickData.state();
-        bs = bs.setValue(TownFlagBlock.SLEEPING, true);
+        bs = bs.setValue(TownFlagBlock.INACTIVE, true);
         tickData.level.setBlockAndUpdate(tickData.blockEntityPos, bs);
     }
 
@@ -284,6 +286,20 @@ public class TownFlagTicker extends AbstractTownFlagTicker<TownFlagTicker.TickDa
             return;
         }
         super.tick(new TickData(sl, blockEntityPos, state, e));
+        spawnBopParticlesIfNeeded(sl, blockEntityPos, e);
+    }
+
+    private void spawnBopParticlesIfNeeded(ServerLevel sl, BlockPos pos, TownFlagBlockEntity e) {
+        if (e.bopCount <= 0) {
+            return;
+        }
+        if (sl.getGameTime() % 20 != 0) {
+            return;
+        }
+        double x = pos.getX() + 0.5 + sl.getRandom().nextGaussian() * 0.3;
+        double y = pos.getY() + 1.2;
+        double z = pos.getZ() + 0.5 + sl.getRandom().nextGaussian() * 0.3;
+        sl.sendParticles(ParticleTypes.HAPPY_VILLAGER, x, y, z, 1, 0, 0.1, 0, 0.01);
     }
 
     public record TickData(ServerLevel level, BlockPos blockEntityPos, BlockState state, TownFlagBlockEntity entity) {

--- a/src/main/resources/data/questown/questown_jobs/armorer_boots.json
+++ b/src/main/resources/data/questown/questown_jobs/armorer_boots.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "id": "armorer/boots",
+  "unlocks_title": "armorer",
+  "priority": "2999",
+  "parent": "crafter/stick",
+  "icon": "minecraft:leather_boots",
+  "initial_request": "minecraft:leather_boots",
+  "result": {
+    "type": "crafting_table",
+    "recipe": ["X X", "X X"],
+    "fallback": "minecraft:leather_boots",
+    "quantity": 1
+  },
+  "block": "questown:blacksmiths_table",
+  "room": "questown:armory",
+  "work_states": [
+    {
+      "ingredients": "minecraft:leather",
+      "quantity": 1
+    },
+    {
+      "work": 40
+    }
+  ],
+  "cooldown_ticks": 25,
+  "sound": {
+    "id": "minecraft:item.armor.equip_leather",
+    "chance": "100",
+    "duration": 5
+  }
+}

--- a/src/main/resources/data/questown/questown_jobs/armorer_chestplate.json
+++ b/src/main/resources/data/questown/questown_jobs/armorer_chestplate.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "id": "armorer/chestplate",
+  "unlocks_title": "armorer",
+  "priority": "2999",
+  "parent": "crafter/stick",
+  "icon": "minecraft:leather_chestplate",
+  "initial_request": "minecraft:leather_chestplate",
+  "result": {
+    "type": "crafting_table",
+    "recipe": ["X X", "XXX", "XXX"],
+    "fallback": "minecraft:leather_chestplate",
+    "quantity": 1
+  },
+  "block": "questown:blacksmiths_table",
+  "room": "questown:armory",
+  "work_states": [
+    {
+      "ingredients": "minecraft:leather",
+      "quantity": 3
+    },
+    {
+      "work": 40
+    }
+  ],
+  "cooldown_ticks": 25,
+  "sound": {
+    "id": "minecraft:item.armor.equip_leather",
+    "chance": "100",
+    "duration": 5
+  }
+}

--- a/src/main/resources/data/questown/questown_jobs/armorer_helmet.json
+++ b/src/main/resources/data/questown/questown_jobs/armorer_helmet.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "id": "armorer/helmet",
+  "unlocks_title": "armorer",
+  "priority": "2999",
+  "parent": "crafter/stick",
+  "icon": "minecraft:leather_helmet",
+  "initial_request": "minecraft:leather_helmet",
+  "result": {
+    "type": "crafting_table",
+    "recipe": ["XXX", "X X"],
+    "fallback": "minecraft:leather_helmet",
+    "quantity": 1
+  },
+  "block": "questown:blacksmiths_table",
+  "room": "questown:armory",
+  "work_states": [
+    {
+      "ingredients": "minecraft:leather",
+      "quantity": 2
+    },
+    {
+      "work": 40
+    }
+  ],
+  "cooldown_ticks": 25,
+  "sound": {
+    "id": "minecraft:item.armor.equip_leather",
+    "chance": "100",
+    "duration": 5
+  }
+}

--- a/src/main/resources/data/questown/questown_jobs/armorer_leggings.json
+++ b/src/main/resources/data/questown/questown_jobs/armorer_leggings.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "id": "armorer/leggings",
+  "unlocks_title": "armorer",
+  "priority": "2999",
+  "parent": "crafter/stick",
+  "icon": "minecraft:leather_leggings",
+  "initial_request": "minecraft:leather_leggings",
+  "result": {
+    "type": "crafting_table",
+    "recipe": ["XXX", "X X", "X X"],
+    "fallback": "minecraft:leather_leggings",
+    "quantity": 1
+  },
+  "block": "questown:blacksmiths_table",
+  "room": "questown:armory",
+  "work_states": [
+    {
+      "ingredients": "minecraft:leather",
+      "quantity": 2
+    },
+    {
+      "work": 40
+    }
+  ],
+  "cooldown_ticks": 25,
+  "sound": {
+    "id": "minecraft:item.armor.equip_leather",
+    "chance": "100",
+    "duration": 5
+  }
+}

--- a/src/main/resources/data/questown/recipes/armory.json
+++ b/src/main/resources/data/questown/recipes/armory.json
@@ -1,0 +1,11 @@
+{
+  "type": "roomrecipes:room",
+  "recipe_strength": 1,
+  "ingredients": [
+    {"item": "questown:blacksmiths_table"},
+    {"tag": "forge:chests"},
+    {"tag": "forge:chests"},
+    {"tag": "forge:chests"},
+    {"tag": "forge:chests"}
+  ]
+}

--- a/src/main/resources/data/questown/tags/items/armor_materials.json
+++ b/src/main/resources/data/questown/tags/items/armor_materials.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:leather",
+    "minecraft:iron_ingot",
+    "minecraft:gold_ingot",
+    "minecraft:diamond"
+  ]
+}

--- a/src/main/resources/data/questown/worldgen/structure/empty_town.json
+++ b/src/main/resources/data/questown/worldgen/structure/empty_town.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:jigsaw",
+  "biomes": "#questown:has_structure/empty_town_biomes",
+  "step": "surface_structures",
+  "spawn_overrides": {},
+  "start_pool": "questown:empty_town/start_pool",
+  "size": 1,
+  "start_height": {
+    "absolute": -1
+  },
+  "use_expansion_hack": false,
+  "project_start_to_heightmap": "WORLD_SURFACE_WG",
+  "max_distance_from_center": 80
+}

--- a/src/main/resources/data/questown/worldgen/structure_set/empty_town.json
+++ b/src/main/resources/data/questown/worldgen/structure_set/empty_town.json
@@ -1,0 +1,14 @@
+{
+  "structures": [
+    {
+      "structure": "questown:empty_town",
+      "weight": 1
+    }
+  ],
+  "placement": {
+    "type": "minecraft:random_spread",
+    "spacing": 48,
+    "separation": 32,
+    "salt": 835770375
+  }
+}

--- a/src/main/resources/data/questown/worldgen/template_pool/empty_town/start_pool.json
+++ b/src/main/resources/data/questown/worldgen/template_pool/empty_town/start_pool.json
@@ -1,0 +1,15 @@
+{
+  "name": "questown:empty_town/start_pool",
+  "fallback": "minecraft:empty",
+  "elements": [
+    {
+      "weight": 1,
+      "element": {
+        "location": "questown:empty_town",
+        "processors": "minecraft:empty",
+        "projection": "rigid",
+        "element_type": "minecraft:single_pool_element"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
New features:
- Campfire sleep via Town Wand (adds Mining Fatigue + Weakness debuff)
- Flag menu crafting tab (untested - intended to replace right-click with item in hand)
- Armorer job: 4 leather armor sub-jobs + armory room recipe
- BOP flag particles and "BOP earned" notification
- Villager idle particles (NO_SUPPLIES -> angry villager)
- Flagpole building via log on flag (untested)
- Empty Town worldgen restored

Etc:
- Fishing station null safety (hasProperty guard)
- Hunger config initialization in SimpleVillagerHandle
- SLEEPING->INACTIVE block property rename