### PR TITLE
Restructure tutorial into guided 7-phase onboarding

### DIFF
--- a/src/main/java/ca/bradj/questown/core/advancements/AdvancementEvents.java
+++ b/src/main/java/ca/bradj/questown/core/advancements/AdvancementEvents.java
@@ -3,6 +3,7 @@ package ca.bradj.questown.core.advancements;
 import ca.bradj.questown.Questown;
 import ca.bradj.questown.mc.Compat;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.event.entity.player.AdvancementEvent;
@@ -12,6 +13,8 @@ import vazkii.patchouli.api.PatchouliAPI;
 
 @Mod.EventBusSubscriber(modid = Questown.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class AdvancementEvents {
+
+    private static final ResourceLocation BOOK_ID = new ResourceLocation(Questown.MODID, "intro");
 
     public static final ImmutableList<String> ADVANCEMENTS_WITH_PAGES = ImmutableList.of(
             VisitorTrigger.Triggers.FirstVisitor.getID(),
@@ -26,9 +29,42 @@ public class AdvancementEvents {
             RoomTrigger.Triggers.FirstJobBoard.getID(),
             RoomTrigger.Triggers.FirstStoreRoom.getID(),
             RoomTrigger.Triggers.FirstWelcomeMat.getID(),
-            RoomTrigger.Triggers.FirstOpenFlagMenu.getID()
+            RoomTrigger.Triggers.FirstOpenFlagMenu.getID(),
+            TutorialTrigger.Triggers.TutorialComplete.getID(),
+            TutorialTrigger.Triggers.SecondJobType.getID(),
+            TutorialTrigger.Triggers.FirstWarp.getID(),
+            TutorialTrigger.Triggers.FirstRoomUpgrade.getID(),
+            TutorialTrigger.Triggers.FirstBopView.getID(),
+            TutorialTrigger.Triggers.FirstBopSpend.getID(),
+            TutorialTrigger.Triggers.Chapter2.getID(),
+            TutorialTrigger.Triggers.Chapter3.getID(),
+            TutorialTrigger.Triggers.Chapter4.getID(),
+            TutorialTrigger.Triggers.FirstCampfireSleep.getID()
     );
 
+    // Maps advancement path → journal entry path to open automatically when the advancement fires.
+    // Entries without a mapping fall back to a chat notification only.
+    private static final ImmutableMap<String, String> ADVANCEMENT_TO_ENTRY = ImmutableMap.<String, String>builder()
+            .put(VisitorTrigger.Triggers.FirstVisitor.getID(),         "002-how-to-start")
+            .put(RoomTrigger.Triggers.WandGet.getID(),                 "003-how-to-register")
+            .put(RoomTrigger.Triggers.FirstRoom.getID(),               "004-job-board")
+            .put(RoomTrigger.Triggers.FirstJobBoard.getID(),           "005-requests")
+            .put(VisitorTrigger.Triggers.FirstJobRequest.getID(),      "006-town-gate")
+            .put(RoomTrigger.Triggers.FirstWelcomeMat.getID(),         "007-storage")
+            .put(RoomTrigger.Triggers.FirstStoreRoom.getID(),          "008-how-to-supply")
+            .put(VisitorTrigger.Triggers.FirstLeaveToGather.getID(),   "009-how-to-monitor")
+            .put(RoomTrigger.Triggers.FirstOpenFlagMenu.getID(),       "010-how-to-progress")
+            .put(VisitorTrigger.Triggers.FirstJobDone.getID(),         "011-how-to-level")
+            // FirstJobQuest fires right after FirstJobDone; omitting it here so 011 isn't immediately overridden
+            .put(VisitorTrigger.Triggers.FirstUnmetNeeds.getID(),      "lesson_needs")
+            .put(RoomTrigger.Triggers.FirstJobBlock.getID(),           "lesson_room_recipes")
+            .put(TutorialTrigger.Triggers.TutorialComplete.getID(),    "013-the-crafter")
+            .put(TutorialTrigger.Triggers.SecondJobType.getID(),       "014-supply-chains")
+            .put(TutorialTrigger.Triggers.FirstWarp.getID(),           "015-while-you-were-away")
+            .put(TutorialTrigger.Triggers.FirstRoomUpgrade.getID(),    "lesson_upgrades")
+            .put(TutorialTrigger.Triggers.FirstBopView.getID(),        "lesson_bop")
+            .put(TutorialTrigger.Triggers.FirstCampfireSleep.getID(),  "lesson_campfire_sleep")
+            .build();
 
     @SubscribeEvent
     public static void entityAttrEvent(AdvancementEvent event) {
@@ -41,10 +77,16 @@ public class AdvancementEvents {
         String path = event.getAdvancement().getId().getPath();
         if ("root".equals(path)) {
             Compat.sendMessage(sp, Compat.translatable("messages.town_flag.first_visit_journal"));
-            sp.addItem(PatchouliAPI.get().getBookStack(new ResourceLocation(Questown.MODID, "intro")));
+            sp.addItem(PatchouliAPI.get().getBookStack(BOOK_ID));
             return;
         }
-        if (ADVANCEMENTS_WITH_PAGES.contains(path)) {
+        if (!ADVANCEMENTS_WITH_PAGES.contains(path)) {
+            return;
+        }
+        String entry = ADVANCEMENT_TO_ENTRY.get(path);
+        if (entry != null) {
+            PatchouliAPI.get().openBookEntry(sp, BOOK_ID, new ResourceLocation(Questown.MODID, entry), 0);
+        } else {
             Compat.sendMessage(sp, Compat.translatable("messages.town_flag.journal_page"));
         }
     }

--- a/src/main/java/ca/bradj/questown/core/advancements/TutorialTrigger.java
+++ b/src/main/java/ca/bradj/questown/core/advancements/TutorialTrigger.java
@@ -1,0 +1,135 @@
+package ca.bradj.questown.core.advancements;
+
+import ca.bradj.questown.Questown;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ImmutableBiMap;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import net.minecraft.advancements.critereon.AbstractCriterionTriggerInstance;
+import net.minecraft.advancements.critereon.DeserializationContext;
+import net.minecraft.advancements.critereon.EntityPredicate;
+import net.minecraft.advancements.critereon.SimpleCriterionTrigger;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
+
+import java.util.function.Predicate;
+
+public class TutorialTrigger extends SimpleCriterionTrigger<TutorialTrigger.Instance> {
+
+    public static final ResourceLocation ID = new ResourceLocation(
+            Questown.MODID, "tutorial_trigger"
+    );
+
+    public void triggerForNearestPlayer(
+            ServerLevel level,
+            Triggers trigger,
+            BlockPos nearPos
+    ) {
+        Player np = level.getNearestPlayer(
+                nearPos.getX(), nearPos.getY(), nearPos.getZ(), 16.0D, false
+        );
+        if (!(np instanceof ServerPlayer sp)) {
+            return;
+        }
+        trigger(sp, trigger);
+    }
+
+    public enum Triggers {
+        Invalid,
+        TutorialComplete,
+        SecondJobType,
+        FirstWarp,
+        FirstRoomUpgrade,
+        FirstBopView,
+        FirstBopSpend,
+        Chapter2,
+        Chapter3,
+        Chapter4,
+        FirstCampfireSleep;
+
+        private static final BiMap<Triggers, String> stringVals = ImmutableBiMap.<Triggers, String>builder()
+                .put(Triggers.TutorialComplete, "tutorial_complete")
+                .put(Triggers.SecondJobType, "second_job_type")
+                .put(Triggers.FirstWarp, "first_warp")
+                .put(Triggers.FirstRoomUpgrade, "first_room_upgrade")
+                .put(Triggers.FirstBopView, "first_bop_view")
+                .put(Triggers.FirstBopSpend, "first_bop_spend")
+                .put(Triggers.Chapter2, "chapter_2")
+                .put(Triggers.Chapter3, "chapter_3")
+                .put(Triggers.Chapter4, "chapter_4")
+                .put(Triggers.FirstCampfireSleep, "first_campfire_sleep")
+                .build();
+
+        public static Triggers fromJSON(JsonElement element) {
+            String key = element.getAsString();
+            if (!stringVals.inverse().containsKey(key)) {
+                throw new IllegalArgumentException(
+                        String.format("Tutorial trigger ID is unexpected: %s", element)
+                );
+            }
+            return stringVals.inverse().get(key);
+        }
+
+        public String getID() {
+            return stringVals.get(this);
+        }
+    }
+
+    @Override
+    public ResourceLocation getId() {
+        return ID;
+    }
+
+    @Override
+    public Instance createInstance(
+            JsonObject json,
+            EntityPredicate.Composite predicate,
+            DeserializationContext parser
+    ) {
+        if (!json.has("context")) {
+            throw new IllegalStateException(String.format(
+                    "Trigger of type %s is missing context [ID: %s]",
+                    ID, parser.getAdvancementId()
+            ));
+        }
+
+        return new TutorialTrigger.Instance(predicate, Triggers.fromJSON(json.get("context")));
+    }
+
+    @Override
+    protected void trigger(
+            ServerPlayer player,
+            Predicate<Instance> predicate
+    ) {
+        super.trigger(player, predicate);
+    }
+
+    public void trigger(
+            ServerPlayer player,
+            Triggers trigger
+    ) {
+        super.trigger(player, instance -> instance.matches(trigger));
+    }
+
+    public static class Instance extends AbstractCriterionTriggerInstance {
+        private final Triggers context;
+
+        public Instance(
+                EntityPredicate.Composite predicate,
+                Triggers context
+        ) {
+            super(TutorialTrigger.ID, predicate);
+            if (Triggers.Invalid.equals(context)) {
+                throw new IllegalArgumentException("context must not be invalid");
+            }
+            this.context = context;
+        }
+
+        public boolean matches(Triggers trigger) {
+            return this.context.equals(trigger);
+        }
+    }
+}

--- a/src/main/java/ca/bradj/questown/core/init/AdvancementsInit.java
+++ b/src/main/java/ca/bradj/questown/core/init/AdvancementsInit.java
@@ -2,6 +2,7 @@ package ca.bradj.questown.core.init;
 
 import ca.bradj.questown.core.advancements.ApproachTownTrigger;
 import ca.bradj.questown.core.advancements.RoomTrigger;
+import ca.bradj.questown.core.advancements.TutorialTrigger;
 import ca.bradj.questown.core.advancements.VisitorTrigger;
 import net.minecraft.advancements.CriteriaTriggers;
 
@@ -10,10 +11,12 @@ public class AdvancementsInit {
     public static ApproachTownTrigger APPROACH_TOWN_TRIGGER;
     public static VisitorTrigger VISITOR_TRIGGER;
     public static RoomTrigger ROOM_TRIGGER;
+    public static TutorialTrigger TUTORIAL_TRIGGER;
 
     public static void register() {
         VISITOR_TRIGGER = CriteriaTriggers.register(new VisitorTrigger());
         ROOM_TRIGGER = CriteriaTriggers.register(new RoomTrigger());
         APPROACH_TOWN_TRIGGER = CriteriaTriggers.register(new ApproachTownTrigger());
+        TUTORIAL_TRIGGER = CriteriaTriggers.register(new TutorialTrigger());
     }
 }

--- a/src/main/java/ca/bradj/questown/town/entity/TownFlagTutorialAdapter.java
+++ b/src/main/java/ca/bradj/questown/town/entity/TownFlagTutorialAdapter.java
@@ -1,0 +1,199 @@
+package ca.bradj.questown.town.entity;
+
+import ca.bradj.questown.core.VillagerUUID;
+import ca.bradj.questown.core.advancements.TutorialTrigger;
+import ca.bradj.questown.core.init.AdvancementsInit;
+import ca.bradj.questown.gui.ItemEconomicsData;
+import ca.bradj.questown.integration.minecraft.MCTownItem;
+import ca.bradj.questown.jobs.JobID;
+import ca.bradj.questown.jobs.ServerJobsRegistry;
+import ca.bradj.questown.jobs.WorksBehaviour;
+import ca.bradj.questown.jobs.gatherer.GathererUnmappedNoToolWorkQtrDay;
+import ca.bradj.questown.mc.Compat;
+import ca.bradj.questown.town.CoreProgression;
+import ca.bradj.questown.town.quests.*;
+import ca.bradj.questown.town.rewards.AddBatchOfQuestsForVisitorReward;
+import ca.bradj.questown.town.rewards.SpawnVisitorReward;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.Ingredient;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Map;
+
+import static ca.bradj.questown.town.entity.TownQuests.defaultQuestCompletionRewards;
+
+class TownFlagTutorialAdapter implements TutorialTownView {
+
+    private final TownFlagBlockEntity flag;
+    private final MCQuestBatches questBatches;
+
+    private TownFlagTutorialAdapter(TownFlagBlockEntity flag, MCQuestBatches questBatches) {
+        this.flag = flag;
+        this.questBatches = questBatches;
+    }
+
+    static TutorialTownView from(TownFlagBlockEntity flag, MCQuestBatches questBatches) {
+        return new TownFlagTutorialAdapter(flag, questBatches);
+    }
+
+    @Override
+    public int villagerCount() {
+        return flag.getVillagerHandle().entities().size();
+    }
+
+    @Override
+    public boolean tutorialBopGranted() {
+        return flag.tutorialBopGranted;
+    }
+
+    @Override
+    public void grantBop(int amount) {
+        flag.bopCount += amount;
+        flag.setChanged();
+    }
+
+    @Override
+    public void markTutorialBopGranted() {
+        flag.tutorialBopGranted = true;
+        flag.setChanged();
+    }
+
+    @Override
+    public void broadcastMessage(String message) {
+        flag.messages.broadcastMessage(message);
+    }
+
+    @Override
+    public void broadcastTutorialToast(String titleKey, String descriptionKey) {
+        flag.messages.broadcastTutorialToast(titleKey, descriptionKey);
+    }
+
+    @Override
+    public void fireTutorialTrigger(TutorialTrigger.Triggers trigger) {
+        if (!(flag.getLevel() instanceof ServerLevel sl)) {
+            return;
+        }
+        AdvancementsInit.TUTORIAL_TRIGGER.triggerForNearestPlayer(sl, trigger, flag.getBlockPos());
+    }
+
+    @Override
+    public ResourceLocation getExoticWood() {
+        return getExoticWoodForTown(flag);
+    }
+
+    @Override
+    @Nullable
+    public JobID chooseJobForTutorial(MCQuestBatches questBatches) {
+        WorksBehaviour.TownData data = flag.getTownData();
+        CoreProgression<JobID, ResourceLocation> prog = new CoreProgression<>(
+                flag.getEconomicsHandle().getAggregatedItems(null),
+                GathererUnmappedNoToolWorkQtrDay.ID::equals,
+                jobs -> Compat.shuffle(jobs.iterator(), flag.getServerLevel()).get(0),
+                j -> producesFood(j),
+                (j, needs) -> resourceImpact(needs, data, j)
+        );
+        return prog.getFirstJobChange(
+                ServerJobsRegistry.getAllRootJobs(),
+                ServerJobsRegistry::getRoomForJobId,
+                q -> questBatches.includes(v -> q.equals(v.getWantedId()))
+        );
+    }
+
+    @Override
+    public ResourceLocation getRoomForJob(JobID job) {
+        return ServerJobsRegistry.getRoomForJobId(job);
+    }
+
+    @Override
+    public MCReward makeReward(String phaseName) {
+        return switch (phaseName) {
+            case TutorialTownView.PHASE_KICKOFF -> new MCRewardList(
+                    flag,
+                    new MCDelayedReward(flag, new SpawnVisitorReward(flag, VillagerUUID.random())),
+                    new MCInstantReward(flag, new AddBatchOfQuestsForVisitorReward(flag, null))
+            );
+            case TutorialTownView.PHASE_HUNTER_GATHERER -> {
+                VillagerUUID nextVisitorUUID = VillagerUUID.random();
+                yield new MCRewardList(
+                        flag,
+                        new MCDelayedReward(flag, new SpawnVisitorReward(flag, VillagerUUID.random())),
+                        new AddBatchOfQuestsForVisitorReward(flag, VillagerUUID.get(nextVisitorUUID))
+                );
+            }
+            case TutorialTownView.PHASE_NEW_JOB_ROOM, TutorialTownView.PHASE_7 ->
+                    new MCDelayedReward(flag, defaultQuestCompletionRewards(flag));
+            default -> new AddBatchOfQuestsForVisitorReward(flag, null);
+        };
+    }
+
+    private boolean producesFood(JobID j) {
+        return ServerJobsRegistry.getResults(flag.getTownData(), j).stream().anyMatch(
+                i -> Ingredient.of(ca.bradj.questown.core.init.TagsInit.Items.VILLAGER_FOOD).test(i.toMCItemStack())
+        );
+    }
+
+    private Collection<ItemEconomicsData> resourceImpact(
+            ImmutableList<ItemEconomicsData> needs,
+            WorksBehaviour.TownData data,
+            JobID j
+    ) {
+        ImmutableSet<MCTownItem> results = ServerJobsRegistry.getResults(data, j);
+        return needs.stream().filter(v -> results.stream().anyMatch(z -> sameItem(v, z))).toList();
+    }
+
+    private static boolean sameItem(ItemEconomicsData v, MCTownItem z) {
+        return ca.bradj.questown.gui.Ingredients.fromString(v.ingredientKey()).test(z.toMCItemStack());
+    }
+
+    static ResourceLocation chooseExoticWood(String biomePath) {
+        Map<String, ResourceLocation> nativeWoods = Map.of(
+                "forest", Compat.getItemId(Items.OAK_LOG),
+                "birch", Compat.getItemId(Items.BIRCH_LOG),
+                "taiga", Compat.getItemId(Items.SPRUCE_LOG),
+                "jungle", Compat.getItemId(Items.JUNGLE_LOG),
+                "savanna", Compat.getItemId(Items.ACACIA_LOG),
+                "dark_forest", Compat.getItemId(Items.DARK_OAK_LOG),
+                "mangrove", Compat.getItemId(Items.MANGROVE_LOG)
+        );
+
+        ImmutableList<ResourceLocation> allWoods = ImmutableList.of(
+                Compat.getItemId(Items.OAK_LOG),
+                Compat.getItemId(Items.BIRCH_LOG),
+                Compat.getItemId(Items.SPRUCE_LOG),
+                Compat.getItemId(Items.JUNGLE_LOG),
+                Compat.getItemId(Items.ACACIA_LOG),
+                Compat.getItemId(Items.DARK_OAK_LOG)
+        );
+
+        ResourceLocation nativeWood = null;
+        for (Map.Entry<String, ResourceLocation> entry : nativeWoods.entrySet()) {
+            if (biomePath.contains(entry.getKey())) {
+                nativeWood = entry.getValue();
+                break;
+            }
+        }
+
+        for (ResourceLocation wood : allWoods) {
+            if (!wood.equals(nativeWood)) {
+                return wood;
+            }
+        }
+
+        return Compat.getItemId(Items.DARK_OAK_LOG);
+    }
+
+    private static ResourceLocation getExoticWoodForTown(TownFlagBlockEntity t) {
+        if (!(t.getLevel() instanceof ServerLevel sl)) {
+            return Compat.getItemId(Items.DARK_OAK_LOG);
+        }
+        String biome = sl.getBiome(t.getBlockPos()).unwrapKey()
+                          .map(k -> k.location().getPath())
+                          .orElse("plains");
+        return chooseExoticWood(biome);
+    }
+}

--- a/src/main/java/ca/bradj/questown/town/entity/TownQuests.java
+++ b/src/main/java/ca/bradj/questown/town/entity/TownQuests.java
@@ -6,23 +6,24 @@ import ca.bradj.questown.blocks.entity.BlockAsRoomEntity;
 import ca.bradj.questown.commands.DebugLogArgument;
 import ca.bradj.questown.core.Config;
 import ca.bradj.questown.core.VillagerUUID;
+import ca.bradj.questown.core.advancements.RoomTrigger;
+import ca.bradj.questown.core.advancements.TutorialTrigger;
+import ca.bradj.questown.core.init.AdvancementsInit;
 import ca.bradj.questown.core.init.TagsInit;
 import ca.bradj.questown.gui.Ingredients;
 import ca.bradj.questown.gui.ItemEconomicsData;
 import ca.bradj.questown.integration.minecraft.MCTownItem;
 import ca.bradj.questown.jobs.JobID;
 import ca.bradj.questown.jobs.ServerJobsRegistry;
-import ca.bradj.questown.jobs.WorksBehaviour;
-import ca.bradj.questown.jobs.gatherer.GathererUnmappedNoToolWorkQtrDay;
 import ca.bradj.questown.logic.RoomRecipes;
 import ca.bradj.questown.mc.Compat;
-import ca.bradj.questown.town.CoreProgression;
 import ca.bradj.questown.town.UnsafeTown;
 import ca.bradj.questown.town.econ.NoMCEconomics;
 import ca.bradj.questown.town.interfaces.TownInterface;
 import ca.bradj.questown.town.quests.*;
 import ca.bradj.questown.town.rewards.*;
 import ca.bradj.questown.town.special.SpecialQuests;
+import ca.bradj.roomrecipes.adapter.Positions;
 import ca.bradj.roomrecipes.adapter.RoomRecipeMatch;
 import ca.bradj.roomrecipes.recipes.ActiveRecipes;
 import ca.bradj.roomrecipes.recipes.RecipesInit;
@@ -316,7 +317,7 @@ public class TownQuests implements QuestBatch.ChangeListener<MCQuest>,
         int size = getVillagers(this).size();
 
         if (!questRequests.isEmpty()) {
-            Tutorial r = addTutorialBatches();
+            Tutorial r = addTutorialBatches(TownFlagTutorialAdapter.from(this.town.getUnsafe(), questBatches));
             switch (r) {
                 case APPLIED -> {
                     this.questRequests.clear();
@@ -345,7 +346,7 @@ public class TownQuests implements QuestBatch.ChangeListener<MCQuest>,
         //  If it has, discard the pending quests and start over.
         if (pendingQuests == null) {
             QT.QUESTS_LOGGER.debug("Preparing quest batch with target weight: {}", targetItemWeight);
-            pendingQuests = new QuestBatchSeed(level, UUID.randomUUID(), targetItemWeight);
+            pendingQuests = new QuestBatchSeed(level, UUID.randomUUID(), targetItemWeight, this.town.getUnsafe().completedProceduralBatches);
         }
 
         QuestBatchSeed pop = pendingQuests;
@@ -411,60 +412,264 @@ public class TownQuests implements QuestBatch.ChangeListener<MCQuest>,
                            .anyMatch(v -> v.getWantedId().equals(JobID.toRL(new JobID("hunter", "sword"))));
     }
 
-    private enum Tutorial {
+    enum Tutorial {
         SKIPPED,
         APPLIED,
         DONE
     }
 
-    private Tutorial addTutorialBatches() {
+    Tutorial addTutorialBatches(TutorialTownView view) {
         if (questBatches.isEmpty()) {
             return Tutorial.SKIPPED;
         }
 
-        TownFlagBlockEntity t = town.getUnsafe();
+        Tutorial r;
+        r = tryPhase1_campfireToKickoff(view);       if (r != null) return r;
+        r = tryPhase2_hunterGatherer(view);           if (r != null) return r;
+        r = tryPhase2_5_jobChangeAndFood(view);       if (r != null) return r;
+        r = tryPhase3_newJobRoom(view);               if (r != null) return r;
+        r = tryPhase4_crafter(view);                  if (r != null) return r;
+        r = tryPhase5_supplyChain(view);              if (r != null) return r;
+        r = tryPhase6_storageUpgrade(view);           if (r != null) return r;
+        r = tryPhase7_exoticWood(view);               if (r != null) return r;
+        return Tutorial.DONE;
+    }
+
+    private @Nullable Tutorial tryPhase1_campfireToKickoff(TutorialTownView view) {
         if (questBatches.hasOneQuestOnly(SpecialQuests.CAMPFIRE::equals)) {
-            // Phase one: Ask for the bare essentials (bedroom, storeroom, job board, gate)
-            addQuestsForVillagerKickoff(t);
+            addQuestsForVillagerKickoff(view);
+            view.broadcastTutorialToast(
+                    "tutorial.visitor_arrived.title",
+                    "tutorial.visitor_arrived.description"
+            );
+            notifyNewQuests(view);
             return Tutorial.APPLIED;
         }
-
         if (!allVillagerKickoffQuestsDone()) {
             return Tutorial.SKIPPED;
         }
+        return null;
+    }
 
-        if (town.getUnsafe().getVillagerHandle().entities().size() < 2) {
+    private @Nullable Tutorial tryPhase2_hunterGatherer(TutorialTownView view) {
+        if (view.villagerCount() < 2) {
             return Tutorial.SKIPPED;
         }
-
-        if (!questBatches.includes(q -> q.getType() == Quest.QuestType.JOB_CHANGE)) {
-            // Phase two: Get the player to hunter-gatherer status
-            addHunterGatherer(t);
-            return Tutorial.APPLIED;
+        if (questBatches.includes(q -> q.getType() == Quest.QuestType.JOB_CHANGE)) {
+            return null;
         }
+        grantTutorialBop(view);
+        addHunterGatherer(view);
+        notifyNewQuests(view);
+        return Tutorial.APPLIED;
+    }
 
-        if (town.getUnsafe().getVillagerHandle().entities().size() < 3) {
+    private @Nullable Tutorial tryPhase2_5_jobChangeAndFood(TutorialTownView view) {
+        if (view.villagerCount() < 3) {
             return Tutorial.SKIPPED;
         }
-
         if (questBatches.getAll().stream().filter(q -> q.getType() == Quest.QuestType.JOB_CHANGE).count() < 2) {
-            // Phase two: Ask the player to complete at least two job changes
-            addQuestsForJobChangeAndFood(t);
+            addQuestsForJobChangeAndFood(view);
+            notifyNewQuests(view);
             return Tutorial.APPLIED;
         }
-
         if (questBatches.getAll().stream().filter(q -> q.getType() == Quest.QuestType.JOB_CHANGE && q.isComplete()).count() < 2) {
             return Tutorial.SKIPPED;
         }
+        return null;
+    }
 
-        @Nullable JobHaver jobToCreateRoomFor = getJobToCreateRoomFor();
-        if (jobToCreateRoomFor != null) {
-            // Phase three: Ask the player to provide the room for the second new (and random) job
-            addQuestForNewJobRoom(t, jobToCreateRoomFor);
+    private @Nullable Tutorial tryPhase3_newJobRoom(TutorialTownView view) {
+        @Nullable JobHaver jobToCreateRoomFor = getJobToCreateRoomFor(view);
+        if (jobToCreateRoomFor == null) {
+            return null;
+        }
+        addQuestForNewJobRoom(view, jobToCreateRoomFor);
+        notifyNewQuests(view);
+        return Tutorial.APPLIED;
+    }
+
+    private @Nullable Tutorial tryPhase4_crafter(TutorialTownView view) {
+        if (!phase4Started()) {
+            view.fireTutorialTrigger(TutorialTrigger.Triggers.TutorialComplete);
+            addPhase4CrafterQuests(view);
+            notifyNewQuests(view);
             return Tutorial.APPLIED;
         }
+        if (!phase4Complete()) {
+            return Tutorial.SKIPPED;
+        }
+        return null;
+    }
 
-        return Tutorial.DONE;
+    private @Nullable Tutorial tryPhase5_supplyChain(TutorialTownView view) {
+        if (!phase5Started()) {
+            addPhase5SupplyChainQuests(view);
+            notifyNewQuests(view);
+            return Tutorial.APPLIED;
+        }
+        if (!phase5Complete()) {
+            return Tutorial.SKIPPED;
+        }
+        return null;
+    }
+
+    private @Nullable Tutorial tryPhase6_storageUpgrade(TutorialTownView view) {
+        if (!phase6Started()) {
+            view.fireTutorialTrigger(TutorialTrigger.Triggers.SecondJobType);
+            addPhase6StorageUpgradeQuest(view);
+            notifyNewQuests(view);
+            return Tutorial.APPLIED;
+        }
+        if (!phase6Complete()) {
+            return Tutorial.SKIPPED;
+        }
+        return null;
+    }
+
+    private @Nullable Tutorial tryPhase7_exoticWood(TutorialTownView view) {
+        if (!phase7Started()) {
+            view.fireTutorialTrigger(TutorialTrigger.Triggers.FirstRoomUpgrade);
+            addPhase7ExoticWoodQuest(view);
+            notifyNewQuests(view);
+            return Tutorial.APPLIED;
+        }
+        if (!phase7Complete()) {
+            return Tutorial.SKIPPED;
+        }
+        return null;
+    }
+
+    private static final ResourceLocation CRAFTER_STICK_JOB = JobID.toRL(new JobID("crafter", "stick"));
+    private static final ResourceLocation CRAFTER_BOWL_JOB = JobID.toRL(new JobID("crafter", "bowl"));
+    private static final ResourceLocation BAKER_BREAD_JOB = JobID.toRL(new JobID("baker", "bread"));
+    private static final ResourceLocation FARMER_JOB = JobID.toRL(new JobID("farmer", "wheat"));
+    private static final ResourceLocation CRAFTING_ROOM = new ResourceLocation("questown", "crafting_room");
+    private static final ResourceLocation KITCHEN_SMALL = new ResourceLocation("questown", "kitchen_small");
+    private static final ResourceLocation STORE_ROOM_MEDIUM = new ResourceLocation("questown", "store_room_medium");
+
+    static final String PHASE_7_FLAVOR_KEYWORD = "flagpole";
+
+    private boolean phase4Started() {
+        return questBatches.includes(q -> CRAFTER_STICK_JOB.equals(q.getWantedId()) && q.getType() == Quest.QuestType.JOB_CHANGE);
+    }
+
+    private boolean phase4Complete() {
+        return questBatches.includes(q -> CRAFTER_BOWL_JOB.equals(q.getWantedId()) && q.getType() == Quest.QuestType.JOB_CHANGE && q.isComplete());
+    }
+
+    private boolean phase5Started() {
+        return questBatches.includes(q -> q.getType() == Quest.QuestType.CONCURRENT_JOBS);
+    }
+
+    private boolean phase5Complete() {
+        return questBatches.includes(q -> q.getType() == Quest.QuestType.CONCURRENT_JOBS && q.isComplete());
+    }
+
+    private boolean phase6Started() {
+        return questBatches.includes(q -> STORE_ROOM_MEDIUM.equals(q.getWantedId()) && q.getType() == Quest.QuestType.ROOM);
+    }
+
+    private boolean phase6Complete() {
+        return questBatches.includes(q -> STORE_ROOM_MEDIUM.equals(q.getWantedId()) && q.getType() == Quest.QuestType.ROOM && q.isComplete());
+    }
+
+    private boolean phase7Started() {
+        return questBatches.includes(q -> q.getType() == Quest.QuestType.ITEM && q.getFlavorText() != null && q.getFlavorText().contains(PHASE_7_FLAVOR_KEYWORD));
+    }
+
+    private boolean phase7Complete() {
+        return questBatches.includes(q -> q.getType() == Quest.QuestType.ITEM && q.getFlavorText() != null && q.getFlavorText().contains(PHASE_7_FLAVOR_KEYWORD) && q.isComplete());
+    }
+
+    private void grantTutorialBop(TutorialTownView view) {
+        if (view.tutorialBopGranted()) {
+            return;
+        }
+        view.grantBop(3);
+        view.markTutorialBopGranted();
+        QT.QUESTS_LOGGER.info("Tutorial BOP grant: 3 BOPs added to flag");
+    }
+
+    private void notifyNewQuests(TutorialTownView view) {
+        view.broadcastMessage("New quests are available! Right-click the town flag to see them.");
+    }
+
+    private void addPhase4CrafterQuests(TutorialTownView view) {
+        // Batch A: Assign crafter + build crafting room
+        UUID batchAUUID = UUID.randomUUID();
+        MCQuestBatch.Inputs batchA = new MCQuestBatch.Inputs(batchAUUID, null);
+
+        MCQuest crafterJobQuest = MCQuest.jobChange(batchAUUID, null, CRAFTER_STICK_JOB);
+        crafterJobQuest.setFlavorText("Your village needs a crafter to automate production. Open a villager's skill tree and spend a Block of Progress to change their job.");
+        batchA.addNewQuest(crafterJobQuest);
+
+        MCQuest craftingRoomQuest = MCQuest.standalone(batchAUUID, null, CRAFTING_ROOM);
+        craftingRoomQuest.setFlavorText("The crafter needs a workshop. Place a crafting table in a room and register the door with your wand.");
+        batchA.addNewQuest(craftingRoomQuest);
+
+        MCQuestBatch batchAQ = batchA.withRewardUponCompletion(view.makeReward(TutorialTownView.PHASE_4A));
+        questBatches.add(batchAQ);
+
+        // Batch B: Specialize crafter to bowl
+        UUID batchBUUID = UUID.randomUUID();
+        MCQuestBatch.Inputs batchB = new MCQuestBatch.Inputs(batchBUUID, null);
+
+        MCQuest bowlJobQuest = MCQuest.jobChange(batchBUUID, null, CRAFTER_BOWL_JOB);
+        bowlJobQuest.setFlavorText("Unlock Bowl Crafting on the skill tree. It costs another Block of Progress -- check the flag's BOP tab if you need more.");
+        batchB.addNewQuest(bowlJobQuest);
+
+        MCQuestBatch batchBQ = batchB.withRewardUponCompletion(view.makeReward(TutorialTownView.PHASE_4B));
+        questBatches.add(batchBQ);
+
+        QT.QUESTS_LOGGER.info("Tutorial phase 4 quests added (crafter + bowl)");
+    }
+
+    private void addPhase5SupplyChainQuests(TutorialTownView view) {
+        UUID batchUUID = UUID.randomUUID();
+        MCQuestBatch.Inputs q = new MCQuestBatch.Inputs(batchUUID, null);
+
+        MCQuest concurrentQuest = MCQuest.concurrentJobs(batchUUID, ImmutableList.of(
+                FARMER_JOB, BAKER_BREAD_JOB, CRAFTER_STICK_JOB
+        ));
+        concurrentQuest.setFlavorText("A thriving village needs many hands. Make sure your farmer, baker, and crafter are all working at the same time.");
+        q.addNewQuest(concurrentQuest);
+
+        MCQuest kitchenQuest = MCQuest.standalone(batchUUID, null, KITCHEN_SMALL);
+        kitchenQuest.setFlavorText("Your baker needs a kitchen. Place a furnace in a room and register the door.");
+        q.addNewQuest(kitchenQuest);
+
+        MCQuestBatch qq = q.withRewardUponCompletion(view.makeReward(TutorialTownView.PHASE_5));
+        questBatches.add(qq);
+        QT.QUESTS_LOGGER.info("Tutorial phase 5 quests added (supply chain)");
+    }
+
+    private void addPhase6StorageUpgradeQuest(TutorialTownView view) {
+        UUID batchUUID = UUID.randomUUID();
+        MCQuestBatch.Inputs q = new MCQuestBatch.Inputs(batchUUID, null);
+
+        MCQuest upgradeQuest = MCQuest.upgrade(batchUUID, null, SpecialQuests.STORE_ROOM_SMALL, STORE_ROOM_MEDIUM);
+        upgradeQuest.setFlavorText("Storage fills fast. Upgrade before production stops.");
+        q.addNewQuest(upgradeQuest);
+
+        MCQuestBatch qq = q.withRewardUponCompletion(view.makeReward(TutorialTownView.PHASE_6));
+        questBatches.add(qq);
+        QT.QUESTS_LOGGER.info("Tutorial phase 6 quest added (storage upgrade)");
+    }
+
+    private void addPhase7ExoticWoodQuest(TutorialTownView view) {
+        ResourceLocation exoticWood = view.getExoticWood();
+        UUID batchUUID = UUID.randomUUID();
+        MCQuestBatch.Inputs q = new MCQuestBatch.Inputs(batchUUID, null);
+
+        MCQuest woodQuest = MCQuest.item(batchUUID, null, exoticWood, 1);
+        String woodName = exoticWood.getPath().replace("_", " ");
+        woodQuest.setFlavorText("Your village deserves a proper " + PHASE_7_FLAVOR_KEYWORD + ". Bring back " + woodName + " from the lands beyond.");
+        q.addNewQuest(woodQuest);
+
+        MCQuestBatch qq = q.withRewardUponCompletion(view.makeReward(TutorialTownView.PHASE_7));
+        questBatches.add(qq);
+        QT.QUESTS_LOGGER.info("Tutorial phase 7 quest added (exotic wood: {})", exoticWood);
     }
 
     private boolean allVillagerKickoffQuestsDone() {
@@ -481,7 +686,7 @@ public class TownQuests implements QuestBatch.ChangeListener<MCQuest>,
     private record JobHaver(VillagerUUID villager, JobID job) {
     }
 
-    private @Nullable JobHaver getJobToCreateRoomFor() {
+    private @Nullable JobHaver getJobToCreateRoomFor(TutorialTownView view) {
         JobHaver jobToUseIfNoQuestsExist = null;
         for (MCQuestBatch batch : questBatches.getAllBatches()) {
             for (MCQuest q : batch.getAll()) {
@@ -499,7 +704,7 @@ public class TownQuests implements QuestBatch.ChangeListener<MCQuest>,
                         batch.getOwner(),
                         JobID.fromRL(q.getWantedId())
                 );
-                if (jobRoomQuestExists(q, batch.getOwner())) {
+                if (jobRoomQuestExists(view, q, batch.getOwner())) {
                     return null;
                 }
             }
@@ -508,11 +713,12 @@ public class TownQuests implements QuestBatch.ChangeListener<MCQuest>,
     }
 
     private boolean jobRoomQuestExists(
+            TutorialTownView view,
             MCQuest jobChange,
             @NotNull VillagerUUID owner
     ) {
         JobID jobId = JobID.fromRL(jobChange.getWantedId());
-        ResourceLocation room = ServerJobsRegistry.getRoomForJobId(jobId);
+        ResourceLocation room = view.getRoomForJob(jobId);
         for (MCQuestBatch batch : questBatches.getAllBatches()) {
             if (batchIsRoomForJob(batch, owner, room)) {
                 return true;
@@ -535,23 +741,33 @@ public class TownQuests implements QuestBatch.ChangeListener<MCQuest>,
         return batch.getAll().stream().allMatch(v -> v.getWantedId().equals(room));
     }
 
-    private static final ImmutableList<ResourceLocation> VILLAGER_KICKOFF_QUESTS = ImmutableList.of(
+    static final ImmutableList<ResourceLocation> VILLAGER_KICKOFF_QUESTS = ImmutableList.of(
             SpecialQuests.TOWN_GATE,
             SpecialQuests.JOB_BOARD,
             SpecialQuests.STORE_ROOM_SMALL
     );
 
-    private void addQuestsForVillagerKickoff(TownInterface town) {
+    private void addQuestsForVillagerKickoff(TutorialTownView view) {
         UUID batchUUID = UUID.randomUUID();
         MCQuestBatch.Inputs q = new MCQuestBatch.Inputs(batchUUID, null);
-        VILLAGER_KICKOFF_QUESTS.forEach(k -> q.addNewQuest(roomQuest(batchUUID, k)));
-        q.addNewQuest(MCQuest.item(batchUUID, null, Compat.getItemId(Items.IRON_SWORD), 1));
 
-        MCQuestBatch qb = q.withRewardUponCompletion(new MCRewardList(
-                town,
-                new MCDelayedReward(town, new SpawnVisitorReward(town, VillagerUUID.random())),
-                new MCInstantReward(town, new AddBatchOfQuestsForVisitorReward(town, null))
-        ));
+        MCQuest jobBoardQuest = roomQuest(batchUUID, SpecialQuests.JOB_BOARD);
+        jobBoardQuest.setFlavorText("Place a wooden sign in a registered room. It will become a Job Board — this is how villagers find work.");
+        q.addNewQuest(jobBoardQuest);
+
+        MCQuest storeRoomQuest = roomQuest(batchUUID, SpecialQuests.STORE_ROOM_SMALL);
+        storeRoomQuest.setFlavorText("Place a chest in a room and register the door. Villagers store their work here.");
+        q.addNewQuest(storeRoomQuest);
+
+        MCQuest gateQuest = roomQuest(batchUUID, SpecialQuests.TOWN_GATE);
+        gateQuest.setFlavorText("Build a fence gate entrance for your town. Villagers need a way in.");
+        q.addNewQuest(gateQuest);
+
+        MCQuest swordQuest = MCQuest.item(batchUUID, null, Compat.getItemId(Items.WOODEN_SWORD), 1);
+        swordQuest.setFlavorText("Craft a wooden sword and place it in your store room chest. Your villager will need it.");
+        q.addNewQuest(swordQuest);
+
+        MCQuestBatch qb = q.withRewardUponCompletion(view.makeReward(TutorialTownView.PHASE_KICKOFF));
         questBatches.add(qb);
         QT.QUESTS_LOGGER.debug("Tutorial quests added to town: {}", qb.toNiceString());
     }
@@ -563,86 +779,61 @@ public class TownQuests implements QuestBatch.ChangeListener<MCQuest>,
         return MCQuest.standalone(batchUUID, null, roomId);
     }
 
-    private void addHunterGatherer(
-            TownFlagBlockEntity town
-    ) {
+    private void addHunterGatherer(TutorialTownView view) {
         UUID batchUUID = UUID.randomUUID();
         MCQuestBatch.Inputs q = new MCQuestBatch.Inputs(batchUUID, null);
-        q.addNewQuest(MCQuest.item(batchUUID, null, Compat.getItemId(Items.MUTTON), 1));
-        q.addNewQuest(MCQuest.jobChange(batchUUID, null, new JobID("hunter", "sword")));
-        q.addNewQuest(MCQuest.standalone(batchUUID, null, SpecialQuests.BEDROOM));
 
-        @Nullable VillagerUUID nextVisitorUUID = VillagerUUID.random();
-        MCQuestBatch qq = q.withRewardUponCompletion(new MCRewardList(
-                        town,
-                        new MCDelayedReward(town, new SpawnVisitorReward(town, VillagerUUID.random())),
-                        new AddBatchOfQuestsForVisitorReward(town, VillagerUUID.get(nextVisitorUUID))
-                )
-        );
+        MCQuest muttonQuest = MCQuest.item(batchUUID, null, Compat.getItemId(Items.MUTTON), 1);
+        muttonQuest.setFlavorText("Hunt a sheep and place the mutton in a store room chest. Your villagers need food.");
+        q.addNewQuest(muttonQuest);
+
+        MCQuest swordQuest = MCQuest.item(batchUUID, null, Compat.getItemId(Items.STONE_SWORD), 1);
+        swordQuest.setFlavorText("Upgrade your villager's weapon. Craft a stone sword and place it in a store room chest.");
+        q.addNewQuest(swordQuest);
+
+        MCQuest hunterQuest = MCQuest.jobChange(batchUUID, null, new JobID("hunter", "sword"));
+        hunterQuest.setFlavorText("Right-click a villager and use Blocks of Progress");
+        q.addNewQuest(hunterQuest);
+
+        MCQuest bedroomQuest = MCQuest.standalone(batchUUID, null, SpecialQuests.BEDROOM);
+        bedroomQuest.setFlavorText("Place a bed in a room and register the door. Villagers need rest.");
+        q.addNewQuest(bedroomQuest);
+
+        MCQuestBatch qq = q.withRewardUponCompletion(view.makeReward(TutorialTownView.PHASE_HUNTER_GATHERER));
         questBatches.add(qq);
         QT.QUESTS_LOGGER.debug("Tutorial batch #1.5 was added to town: {}", qq.toNiceString());
     }
 
-    private void addQuestsForJobChangeAndFood(
-            TownFlagBlockEntity town
-    ) {
+    private void addQuestsForJobChangeAndFood(TutorialTownView view) {
         UUID batchUUID = UUID.randomUUID();
         MCQuestBatch.Inputs q = new MCQuestBatch.Inputs(batchUUID, null);
-        WorksBehaviour.TownData data = town.getTownData();
-        CoreProgression<JobID, ResourceLocation> prog = new CoreProgression<>(
-                town.getEconomicsHandle().getAggregatedItems(null),
-                GathererUnmappedNoToolWorkQtrDay.ID::equals,
-                jobs -> Compat.shuffle(jobs.iterator(), town.getServerLevel()).get(0),
-                j -> producesFood(town, j),
-                (j, needs) -> resourceImpact(needs, data, j)
-        );
-        JobID jc = getJobForFirstChangeQuest(prog);
-        q.addNewQuest(MCQuest.item(batchUUID, null, Compat.getItemId(Items.APPLE), 10));
-        q.addNewQuest(MCQuest.jobChange(batchUUID, null, jc));
+        JobID jc = view.chooseJobForTutorial(questBatches);
 
-        MCQuestBatch qq = q.withRewardUponCompletion(new AddBatchOfQuestsForVisitorReward(town, null));
+        MCQuest appleQuest = MCQuest.item(batchUUID, null, Compat.getItemId(Items.APPLE), 10);
+        appleQuest.setFlavorText("Gather apples and place them in a store room chest. A growing village needs supplies.");
+        q.addNewQuest(appleQuest);
+
+        MCQuest jobQuest = MCQuest.jobChange(batchUUID, null, jc);
+        jobQuest.setFlavorText("Your town needs variety. Open a villager's skill tree and assign a new job.");
+        q.addNewQuest(jobQuest);
+
+        MCQuestBatch qq = q.withRewardUponCompletion(view.makeReward(TutorialTownView.PHASE_JOB_CHANGE_FOOD));
         questBatches.add(qq);
         QT.QUESTS_LOGGER.debug("Tutorial batch #2 was added to town: {}", qq.toNiceString());
     }
 
     private void addQuestForNewJobRoom(
-            TownFlagBlockEntity t,
+            TutorialTownView view,
             JobHaver job
     ) {
         UUID batchUUID = UUID.randomUUID();
         MCQuestBatch.Inputs q = new MCQuestBatch.Inputs(batchUUID, null);
-        ResourceLocation room = ServerJobsRegistry.getRoomForJobId(job.job());
+        ResourceLocation room = view.getRoomForJob(job.job());
         q.addNewQuest(MCQuest.standalone(batchUUID, job.villager(), room));
 
-        // TODO: Add a quest for supplying the new worker with whatever they need
-//        ImmutableList<Ingredient> wanted = ServerJobsRegistry.getWantedResourcesProvider(job.job())
-//                                                             .apply(ImmutableList.of());
-//        for (Ingredient ingredient : wanted) {
-//            q.addNewQuest(MCQuest.item(batchUUID, job.villager(), Ingredients.toRL(), 1));
-//        }
-
-        MCQuestBatch qq = q.withRewardUponCompletion(new MCDelayedReward(
-                town.getUnsafe(), defaultQuestCompletionRewards(town.getUnsafe())
-        ));
+        MCQuestBatch qq = q.withRewardUponCompletion(view.makeReward(TutorialTownView.PHASE_NEW_JOB_ROOM));
         questBatches.add(qq);
         QT.QUESTS_LOGGER.debug("Tutorial batch #3 was added to town: {}", qq.toNiceString());
-    }
-
-    private @Nullable JobID getJobForFirstChangeQuest(CoreProgression<JobID, ResourceLocation> prog) {
-        return prog.getFirstJobChange(
-                ServerJobsRegistry.getAllRootJobs(),
-                ServerJobsRegistry::getRoomForJobId,
-                q -> questBatches.includes(v -> q.equals(v.getWantedId()))
-        );
-    }
-
-    private Collection<ItemEconomicsData> resourceImpact(
-            ImmutableList<ItemEconomicsData> needs,
-            WorksBehaviour.TownData data,
-            JobID j
-    ) {
-        ImmutableSet<MCTownItem> results = ServerJobsRegistry.getResults(data, j);
-        return needs.stream().filter(v -> results.stream().anyMatch(z -> sameItem(v, z))).toList();
     }
 
     private ImmutableList<RoomNeed<ResourceLocation>> getNeededRooms(NoMCEconomics economicsHandle) {
@@ -698,14 +889,44 @@ public class TownQuests implements QuestBatch.ChangeListener<MCQuest>,
         t.setChanged();
     }
 
+    static boolean isProceduralBatch(QuestBatch<?, ?, ?, ?> batch) {
+        return batch.getAll().stream().anyMatch(q -> {
+            Object id = q.getWantedId();
+            return !(id instanceof ResourceLocation rl) || !SpecialQuests.isSpecialQuestId(rl);
+        });
+    }
+
     @Override
     public void questBatchCompleted(QuestBatch<?, ?, ?, ?> quest) {
         town.getUnsafe().setChanged();
         String completionMessage = quest.getCompletionMessage();
-        if (completionMessage == null || completionMessage.isBlank()) {
+        if (completionMessage != null && !completionMessage.isBlank()) {
+            town.getUnsafe().messages.broadcastMessage(completionMessage);
+        }
+        if (isProceduralBatch(quest)) {
+            fireChapterMilestonesIfNeeded();
+        }
+    }
+
+    private void fireChapterMilestonesIfNeeded() {
+        TownFlagBlockEntity t = town.getUnsafe();
+        t.completedProceduralBatches++;
+        if (t.completedProceduralBatches == 1) {
+            t.messages.broadcastMessage("messages.tutorial.complete");
+        } else if (t.completedProceduralBatches == 5) {
+            fireChapterTrigger(t, TutorialTrigger.Triggers.Chapter2);
+        } else if (t.completedProceduralBatches == 10) {
+            fireChapterTrigger(t, TutorialTrigger.Triggers.Chapter3);
+        } else if (t.completedProceduralBatches == 20) {
+            fireChapterTrigger(t, TutorialTrigger.Triggers.Chapter4);
+        }
+    }
+
+    private static void fireChapterTrigger(TownFlagBlockEntity t, TutorialTrigger.Triggers trigger) {
+        if (!(t.getLevel() instanceof ServerLevel sl)) {
             return;
         }
-        town.getUnsafe().messages.broadcastMessage(completionMessage);
+        AdvancementsInit.TUTORIAL_TRIGGER.triggerForNearestPlayer(sl, trigger, t.getBlockPos());
     }
 
     public ImmutableList<Quest<ResourceLocation, MCRoom>> getAll() {
@@ -763,7 +984,33 @@ public class TownQuests implements QuestBatch.ChangeListener<MCQuest>,
             RoomRecipeMatch<MCRoom> match
     ) {
         ServerLevel l = town.getServerLevelUnsafe();
-        runForTopMatch(this::recipesFromLevel, match, r -> markQuestAsComplete(room, r));
+        runForTopMatch(this::recipesFromLevel, match, r -> {
+            markQuestAsComplete(room, r);
+            if (isWorkBlockRoom(r)) {
+                AdvancementsInit.ROOM_TRIGGER.triggerForNearestPlayer(
+                        l,
+                        RoomTrigger.Triggers.FirstJobBlock,
+                        Positions.ToBlock(room.getDoorPos(), room.yCoord)
+                );
+            }
+        });
+    }
+
+    private static final ImmutableSet<ResourceLocation> NON_WORK_ROOMS = ImmutableSet.of(
+            SpecialQuests.CAMPFIRE,
+            SpecialQuests.BROKEN,
+            SpecialQuests.TOWN_GATE,
+            SpecialQuests.TOWN_FLAG,
+            SpecialQuests.FARM,
+            SpecialQuests.BEDROOM,
+            SpecialQuests.STORE_ROOM_SMALL,
+            SpecialQuests.JOB_BOARD,
+            SpecialQuests.DINING_ROOM,
+            SpecialQuests.CLINIC
+    );
+
+    private static boolean isWorkBlockRoom(ResourceLocation recipeId) {
+        return !SpecialQuests.isSpecialQuest(recipeId) && !NON_WORK_ROOMS.contains(recipeId);
     }
 
     private Map<ResourceLocation, RoomRecipe> recipesFromLevel() {
@@ -851,6 +1098,27 @@ public class TownQuests implements QuestBatch.ChangeListener<MCQuest>,
                 QT.QUESTS_LOGGER.debug("Job change quest owner changed from null to {}", owner);
                 batch.setOwner(owner);
                 batch.markRecipeAsComplete(null, q.getWantedId());
+            }
+        }
+    }
+
+    public void processConcurrentJobs(ImmutableMap<VillagerUUID, JobID> villagerJobs) {
+        Set<ResourceLocation> activeJobRLs = villagerJobs.values().stream()
+                                                          .map(JobID::toRL)
+                                                          .collect(Collectors.toSet());
+        for (MCQuestBatch batch : questBatches.getAllBatches()) {
+            for (MCQuest q : batch.getAll()) {
+                if (q.getType() != Quest.QuestType.CONCURRENT_JOBS) {
+                    continue;
+                }
+                if (q.isComplete()) {
+                    continue;
+                }
+                Collection<ResourceLocation> required = q.getConcurrentJobIds();
+                if (activeJobRLs.containsAll(required)) {
+                    batch.markRecipeAsComplete(null, q.getWantedId());
+                    return;
+                }
             }
         }
     }

--- a/src/main/java/ca/bradj/questown/town/entity/TownQuestsHandle.java
+++ b/src/main/java/ca/bradj/questown/town/entity/TownQuestsHandle.java
@@ -112,7 +112,8 @@ public class TownQuestsHandle implements QuestsHolder {
                         );
                     }
                 }, data ->
-                        FlagMenus.writeAndLink(data, quests, t.getInfo(), player, entities, t.bopCount)
+                        FlagMenus.writeAndLink(data, quests, t.getInfo(), player, entities, t.bopCount,
+                                () -> t.hasVillagerArrivingInMorning())
         );
     }
 

--- a/src/main/java/ca/bradj/questown/town/entity/TutorialTownView.java
+++ b/src/main/java/ca/bradj/questown/town/entity/TutorialTownView.java
@@ -1,0 +1,45 @@
+package ca.bradj.questown.town.entity;
+
+import ca.bradj.questown.core.advancements.TutorialTrigger;
+import ca.bradj.questown.jobs.JobID;
+import ca.bradj.questown.town.quests.MCQuestBatches;
+import ca.bradj.questown.town.quests.MCReward;
+import net.minecraft.resources.ResourceLocation;
+
+import javax.annotation.Nullable;
+
+public interface TutorialTownView {
+
+    String PHASE_KICKOFF = "kickoff";
+    String PHASE_HUNTER_GATHERER = "hunterGatherer";
+    String PHASE_JOB_CHANGE_FOOD = "jobChangeAndFood";
+    String PHASE_NEW_JOB_ROOM = "newJobRoom";
+    String PHASE_4A = "phase4a";
+    String PHASE_4B = "phase4b";
+    String PHASE_5 = "phase5";
+    String PHASE_6 = "phase6";
+    String PHASE_7 = "phase7";
+
+    int villagerCount();
+
+    boolean tutorialBopGranted();
+
+    void grantBop(int amount);
+
+    void markTutorialBopGranted();
+
+    void broadcastMessage(String message);
+
+    void broadcastTutorialToast(String titleKey, String descriptionKey);
+
+    void fireTutorialTrigger(TutorialTrigger.Triggers trigger);
+
+    ResourceLocation getExoticWood();
+
+    @Nullable
+    JobID chooseJobForTutorial(MCQuestBatches questBatches);
+
+    ResourceLocation getRoomForJob(JobID job);
+
+    MCReward makeReward(String phaseName);
+}

--- a/src/main/java/ca/bradj/questown/town/quests/MCMorningRewards.java
+++ b/src/main/java/ca/bradj/questown/town/quests/MCMorningRewards.java
@@ -1,6 +1,7 @@
 package ca.bradj.questown.town.quests;
 
 import ca.bradj.questown.town.interfaces.TownInterface;
+import ca.bradj.questown.town.rewards.SpawnVisitorReward;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.nbt.CompoundTag;
 
@@ -32,6 +33,10 @@ public class MCMorningRewards extends MCRewardList {
     @Override
     public Collection<MCReward> getChildren() {
         return ImmutableList.copyOf(this.currentChildren);
+    }
+
+    public boolean hasPendingSpawnVisitor() {
+        return currentChildren.stream().anyMatch(r -> r instanceof SpawnVisitorReward);
     }
 
     public Collection<MCReward> popChildren() {

--- a/src/main/java/ca/bradj/questown/town/quests/MCQuest.java
+++ b/src/main/java/ca/bradj/questown/town/quests/MCQuest.java
@@ -11,11 +11,14 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class MCQuest extends Quest<ResourceLocation, MCRoom> {
     public static final Serializer SERIALIZER = new Serializer();
 
+    @Nullable String concurrentJobIdsEncoded;
 
     MCQuest() {
         super();
@@ -84,6 +87,31 @@ public class MCQuest extends Quest<ResourceLocation, MCRoom> {
         return new MCQuest(batchUUID, ownerId, jobId, null, QuestType.JOB_CHANGE, 1);
     }
 
+    public static MCQuest concurrentJobs(
+            UUID batchUUID,
+            Collection<ResourceLocation> jobIds
+    ) {
+        String encoded = jobIds.stream().map(ResourceLocation::toString).collect(Collectors.joining(","));
+        ResourceLocation encodedRL = new ResourceLocation("questown", "concurrent_jobs");
+        MCQuest quest = new MCQuest(batchUUID, null, encodedRL, null, QuestType.CONCURRENT_JOBS, 1);
+        quest.concurrentJobIdsEncoded = encoded;
+        return quest;
+    }
+
+    public Collection<ResourceLocation> getConcurrentJobIds() {
+        if (getType() != QuestType.CONCURRENT_JOBS) {
+            return ImmutableList.of();
+        }
+        if (concurrentJobIdsEncoded == null || concurrentJobIdsEncoded.isEmpty()) {
+            return ImmutableList.of();
+        }
+        ImmutableList.Builder<ResourceLocation> b = ImmutableList.builder();
+        for (String s : concurrentJobIdsEncoded.split(",")) {
+            b.add(new ResourceLocation(s));
+        }
+        return b.build();
+    }
+
     // TODO: Consider changing this to a door instead of a room, since the room can change shape easily
     //  and when the door is removed, the quest is invalidated anyway.
     public MCQuest completed(@Nullable MCRoom room) {
@@ -98,6 +126,8 @@ public class MCQuest extends Quest<ResourceLocation, MCRoom> {
         q.ownerUUID = this.ownerUUID;
         q.status = QuestStatus.COMPLETED;
         q.completedOn = room;
+        q.setFlavorText(this.getFlavorText());
+        q.concurrentJobIdsEncoded = this.concurrentJobIdsEncoded;
         return q;
     }
 
@@ -123,6 +153,8 @@ public class MCQuest extends Quest<ResourceLocation, MCRoom> {
         private static final String NBT_COUNT = "count";
         private static final String NBT_RECIPE_ID = "recipe_id";
         private static final String NBT_FROM_RECIPE_ID = "from_recipe_id";
+        private static final String NBT_FLAVOR_TEXT = "flavor_text";
+        private static final String NBT_CONCURRENT_JOB_IDS = "concurrent_job_ids";
         private static final String NBT_STATUS = "status";
         private static final String NBT_COMPLETED_ON_DOORPOS_X = "doorpos_x";
         private static final String NBT_COMPLETED_ON_DOORPOS_Y = "doorpos_y";
@@ -152,6 +184,12 @@ public class MCQuest extends Quest<ResourceLocation, MCRoom> {
 
             if (quest.fromRecipeID().isPresent()) {
                 ct.putString(NBT_FROM_RECIPE_ID, quest.fromRecipeID().get().toString());
+            }
+            if (quest.getFlavorText() != null) {
+                ct.putString(NBT_FLAVOR_TEXT, quest.getFlavorText());
+            }
+            if (quest instanceof MCQuest mcq && mcq.concurrentJobIdsEncoded != null) {
+                ct.putString(NBT_CONCURRENT_JOB_IDS, mcq.concurrentJobIdsEncoded);
             }
             return ct;
         }
@@ -201,6 +239,12 @@ public class MCQuest extends Quest<ResourceLocation, MCRoom> {
                     new MCRoom(doorPos, ImmutableList.of(space), doorY),
                     fromRecipeId
             );
+            if (nbt.contains(NBT_FLAVOR_TEXT)) {
+                quest.setFlavorText(nbt.getString(NBT_FLAVOR_TEXT));
+            }
+            if (nbt.contains(NBT_CONCURRENT_JOB_IDS)) {
+                quest.concurrentJobIdsEncoded = nbt.getString(NBT_CONCURRENT_JOB_IDS);
+            }
             return quest;
         }
 

--- a/src/main/java/ca/bradj/questown/town/quests/PendingQuestsSerializer.java
+++ b/src/main/java/ca/bradj/questown/town/quests/PendingQuestsSerializer.java
@@ -48,7 +48,7 @@ public class PendingQuestsSerializer {
             CompoundTag tag = aq.getCompound(i);
             MCQuestBatch b = MCQuestBatch.SERIALIZER.deserializeNBT(town, tag);
             int threshold = tag.getInt(NBT_WEIGHT_THRESHOLD);
-            QuestBatchSeed pendingQuests = new QuestBatchSeed(town.getServerLevel(), b.getBatchUUID(), threshold);
+            QuestBatchSeed pendingQuests = new QuestBatchSeed(town.getServerLevel(), b.getBatchUUID(), threshold, Integer.MAX_VALUE);
             for (Quest<ResourceLocation, MCRoom> q : b.getAll()) {
                 pendingQuests.batch.addNewQuest(q.getUUID(), q.getWantedId());
             }

--- a/src/main/java/ca/bradj/questown/town/quests/Quest.java
+++ b/src/main/java/ca/bradj/questown/town/quests/Quest.java
@@ -22,6 +22,8 @@ public class Quest<KEY, ROOM extends Room> implements Completable {
     private int count;
     @Nullable
     KEY fromRecipeID;
+    @Nullable
+    private String flavorText;
 
     Quest() {
         this(null, null, null, null, null, 1);
@@ -116,6 +118,15 @@ public class Quest<KEY, ROOM extends Room> implements Completable {
         return count;
     }
 
+    @Nullable
+    public String getFlavorText() {
+        return flavorText;
+    }
+
+    public void setFlavorText(@Nullable String flavorText) {
+        this.flavorText = flavorText;
+    }
+
     public enum QuestStatus {
         UNSET(""),
         ACTIVE("active"),
@@ -143,7 +154,7 @@ public class Quest<KEY, ROOM extends Room> implements Completable {
     }
 
     public enum QuestType {
-        ITEM, ROOM, JOB_CHANGE, UNKNOWN;
+        ITEM, ROOM, JOB_CHANGE, CONCURRENT_JOBS, UNKNOWN;
     }
 
     protected interface QuestFactory<KEY, ROOM extends Room, QUEST extends Quest<KEY, ROOM>> {

--- a/src/main/java/ca/bradj/questown/town/quests/QuestBatchSeed.java
+++ b/src/main/java/ca/bradj/questown/town/quests/QuestBatchSeed.java
@@ -11,6 +11,7 @@ import ca.bradj.questown.town.special.SpecialQuests;
 import ca.bradj.roomrecipes.recipes.RoomRecipe;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.core.NonNullList;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.tags.ItemTags;
@@ -23,6 +24,7 @@ import java.util.function.Supplier;
 public class QuestBatchSeed extends AbstractQuestGarden<MCQuestBatch, ResourceLocation> {
 
     private final ServerLevel level;
+    private final int completedProceduralBatches;
 
     public MCQuestBatch get(
             MCReward rw,
@@ -36,10 +38,12 @@ public class QuestBatchSeed extends AbstractQuestGarden<MCQuestBatch, ResourceLo
     public QuestBatchSeed(
             ServerLevel level,
             UUID batchUUID,
-            int targetItemWeight
+            int targetItemWeight,
+            int completedProceduralBatches
     ) {
         super(Config.IDEAL_QUEST_THRESHOLD_TICKS.get(), Config.QUEST_GENERATION_MAX_TICKS.get(), targetItemWeight);
         this.level = level;
+        this.completedProceduralBatches = completedProceduralBatches;
         this.batch = new MCQuestBatch(batchUUID, null, null);
     }
 
@@ -103,6 +107,12 @@ public class QuestBatchSeed extends AbstractQuestGarden<MCQuestBatch, ResourceLo
             ResourceLocation next
     ) {
         mcQuestBatch.addNewQuest(null, next);
+        if (completedProceduralBatches < 3) {
+            List<MCQuest> all = mcQuestBatch.getAll();
+            MCQuest quest = all.get(all.size() - 1);
+            Component roomName = RoomRecipes.getName(next);
+            quest.setFlavorText(String.format("Your village needs a %s. Build one to keep production flowing.", roomName.getString()));
+        }
     }
 
     @Override

--- a/src/main/java/ca/bradj/questown/town/quests/QuestBatches.java
+++ b/src/main/java/ca/bradj/questown/town/quests/QuestBatches.java
@@ -181,6 +181,7 @@ public class QuestBatches<
                     case ITEM -> e.addItemQuest(owner, q.getWantedId(), q.getCountNeeded());
                     case ROOM -> e.addNewQuest(owner, q.getWantedId());
                     case JOB_CHANGE -> e.addJobChangeQuest(q.getWantedId());
+                    case CONCURRENT_JOBS -> e.addNewQuest(owner, q.getWantedId());
                     case UNKNOWN -> QT.QUESTS_LOGGER.error("Unexpected type: {}. Skipping duplicate check.", q.getType());
                 }
                 IdIgnoring<QUEST> iq = new IdIgnoring<>(q);

--- a/src/main/java/ca/bradj/questown/town/special/SpecialQuests.java
+++ b/src/main/java/ca/bradj/questown/town/special/SpecialQuests.java
@@ -1,6 +1,5 @@
 package ca.bradj.questown.town.special;
 
-import ca.bradj.questown.Questown;
 import ca.bradj.questown.blocks.PlateBlock;
 import ca.bradj.questown.blocks.TownFlagBlock;
 import ca.bradj.questown.blocks.WelcomeMatBlock;
@@ -15,42 +14,75 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 
 import java.util.Map;
+import java.util.Set;
 
 public class SpecialQuests {
 
-    public static final ResourceLocation CAMPFIRE = new ResourceLocation(Questown.MODID, "special_quest.campfire");
-    public static final ResourceLocation BROKEN = new ResourceLocation(Questown.MODID, "special_quest.broken");
-    public static final ResourceLocation TOWN_GATE = new ResourceLocation(Questown.MODID, "special_quest.town_gate");
-    public static final ResourceLocation TOWN_FLAG = new ResourceLocation(Questown.MODID, "special_quest.town_flag");
-    public static final ResourceLocation FARM = new ResourceLocation(Questown.MODID, "special_quest.farm");
+    private static final String MOD = "questown";
 
-    public static final Map<ResourceLocation, RoomRecipe> SPECIAL_QUESTS = ImmutableMap.of(
-            BROKEN,
-            new RoomRecipe(BROKEN, NonNullList.create(), Integer.MAX_VALUE, false),
-            CAMPFIRE,
-            new RoomRecipe(CAMPFIRE, NonNullList.withSize(1, Ingredient.of(Items.CAMPFIRE)), Integer.MAX_VALUE, false),
-            TOWN_GATE,
-            new RoomRecipe(
+    public static final ResourceLocation CAMPFIRE = new ResourceLocation(MOD, "special_quest.campfire");
+    public static final ResourceLocation BROKEN = new ResourceLocation(MOD, "special_quest.broken");
+    public static final ResourceLocation TOWN_GATE = new ResourceLocation(MOD, "special_quest.town_gate");
+    public static final ResourceLocation TOWN_FLAG = new ResourceLocation(MOD, "special_quest.town_flag");
+    public static final ResourceLocation FARM = new ResourceLocation(MOD, "special_quest.farm");
+    public static final ResourceLocation BEDROOM = new ResourceLocation(MOD, "bedroom");
+    public static final ResourceLocation JOB_BOARD = new ResourceLocation(MOD, "job_board");
+    public static final ResourceLocation STORE_ROOM_SMALL = new ResourceLocation(MOD, "store_room");
+    public static final ResourceLocation DINING_ROOM = new ResourceLocation(MOD, "dining_room");
+    public static final ResourceLocation CLINIC = new ResourceLocation(MOD, "clinic");
+
+    private static volatile Map<ResourceLocation, RoomRecipe> specialQuestsCache;
+
+    public static Map<ResourceLocation, RoomRecipe> getSpecialQuests() {
+        if (specialQuestsCache == null) {
+            specialQuestsCache = ImmutableMap.of(
+                    BROKEN,
+                    new RoomRecipe(BROKEN, NonNullList.create(), Integer.MAX_VALUE, false),
+                    CAMPFIRE,
+                    new RoomRecipe(CAMPFIRE, NonNullList.withSize(1, Ingredient.of(Items.CAMPFIRE)), Integer.MAX_VALUE, false),
                     TOWN_GATE,
-                    NonNullList.withSize(1, Ingredient.of(ItemsInit.WELCOME_MAT_BLOCK.get())),
-                    Integer.MAX_VALUE,
-                    false
-            ),
-            TOWN_FLAG,
-            new RoomRecipe(
+                    new RoomRecipe(
+                            TOWN_GATE,
+                            NonNullList.withSize(1, Ingredient.of(ItemsInit.WELCOME_MAT_BLOCK.get())),
+                            Integer.MAX_VALUE,
+                            false
+                    ),
                     TOWN_FLAG,
-                    NonNullList.withSize(1, Ingredient.of(ItemsInit.TOWN_FLAG_BLOCK.get())),
-                    Integer.MAX_VALUE,
-                    false
-            ),
-            FARM,
-            new RoomRecipe(FARM, NonNullList.withSize(1, Ingredient.of(Items.DIRT)), Integer.MAX_VALUE, true)
-    );
-    public static final ResourceLocation BEDROOM = Questown.ResourceLocation("bedroom");
-    public static final ResourceLocation JOB_BOARD = Questown.ResourceLocation("job_board");
-    public static final ResourceLocation STORE_ROOM_SMALL = Questown.ResourceLocation("store_room");
-    public static final ResourceLocation DINING_ROOM = Questown.ResourceLocation("dining_room");
-    public static final ResourceLocation CLINIC = Questown.ResourceLocation("clinic");
+                    new RoomRecipe(
+                            TOWN_FLAG,
+                            NonNullList.withSize(1, Ingredient.of(ItemsInit.TOWN_FLAG_BLOCK.get())),
+                            Integer.MAX_VALUE,
+                            false
+                    ),
+                    FARM,
+                    new RoomRecipe(FARM, NonNullList.withSize(1, Ingredient.of(Items.DIRT)), Integer.MAX_VALUE, true)
+            );
+        }
+        return specialQuestsCache;
+    }
+
+    @Deprecated
+    public static final Map<ResourceLocation, RoomRecipe> SPECIAL_QUESTS = new java.util.AbstractMap<>() {
+        @Override
+        public java.util.Set<Entry<ResourceLocation, RoomRecipe>> entrySet() {
+            return getSpecialQuests().entrySet();
+        }
+
+        @Override
+        public RoomRecipe get(Object key) {
+            return getSpecialQuests().get(key);
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+            return getSpecialQuests().containsKey(key);
+        }
+
+        @Override
+        public int size() {
+            return getSpecialQuests().size();
+        }
+    };
     public static final WorkLocation TOWN_GATE_LOCATION = new WorkLocation(
             ctx -> SpecialQuests.isWelcomeMat(ctx.blockInfo(), ctx.blockPos()),
             SpecialQuests::isWelcomeMat,
@@ -66,6 +98,14 @@ public class SpecialQuests {
             (info, pos) -> WorkLocation.isBlock(PlateBlock.class).test(info, pos),
             SpecialQuests.DINING_ROOM
     );
+
+    private static final Set<ResourceLocation> SPECIAL_QUEST_IDS = new java.util.HashSet<>(java.util.Arrays.asList(
+            BROKEN, CAMPFIRE, TOWN_GATE, TOWN_FLAG, FARM
+    ));
+
+    public static boolean isSpecialQuestId(ResourceLocation id) {
+        return SPECIAL_QUEST_IDS.contains(id);
+    }
 
     public static boolean isSpecialQuest(ResourceLocation id) {
         return SPECIAL_QUESTS.containsKey(id);

--- a/src/main/resources/data/questown/advancements/chapter_2.json
+++ b/src/main/resources/data/questown/advancements/chapter_2.json
@@ -1,14 +1,14 @@
 {
   "display": {
     "title": {
-      "text": "Magic Stick",
+      "text": "Feeding the Village",
       "color": "white"
     },
     "description": {
-      "text": "Acquire a Town Wand from the flag's crafting tab"
+      "text": "Complete 5 procedural quest batches after the tutorial"
     },
     "icon": {
-      "item": "questown:town_wand"
+      "item": "minecraft:bread"
     },
     "frame": "goal",
     "show_toast": true,
@@ -18,9 +18,9 @@
   },
   "criteria": {
     "Trigger": {
-      "trigger": "questown:room_trigger",
+      "trigger": "questown:tutorial_trigger",
       "conditions": {
-        "context": "wand_get"
+        "context": "chapter_2"
       }
     }
   },
@@ -30,7 +30,7 @@
     ]
   ],
   "rewards": {
-    "experience": 100
+    "experience": 200
   },
-  "parent": "questown:first_visitor"
+  "parent": "questown:first_warp"
 }

--- a/src/main/resources/data/questown/advancements/chapter_3.json
+++ b/src/main/resources/data/questown/advancements/chapter_3.json
@@ -1,14 +1,14 @@
 {
   "display": {
     "title": {
-      "text": "Magic Stick",
+      "text": "Tools of the Trade",
       "color": "white"
     },
     "description": {
-      "text": "Acquire a Town Wand from the flag's crafting tab"
+      "text": "Complete 10 procedural quest batches"
     },
     "icon": {
-      "item": "questown:town_wand"
+      "item": "minecraft:iron_pickaxe"
     },
     "frame": "goal",
     "show_toast": true,
@@ -18,9 +18,9 @@
   },
   "criteria": {
     "Trigger": {
-      "trigger": "questown:room_trigger",
+      "trigger": "questown:tutorial_trigger",
       "conditions": {
-        "context": "wand_get"
+        "context": "chapter_3"
       }
     }
   },
@@ -30,7 +30,7 @@
     ]
   ],
   "rewards": {
-    "experience": 100
+    "experience": 300
   },
-  "parent": "questown:first_visitor"
+  "parent": "questown:chapter_2"
 }

--- a/src/main/resources/data/questown/advancements/chapter_4.json
+++ b/src/main/resources/data/questown/advancements/chapter_4.json
@@ -1,16 +1,16 @@
 {
   "display": {
     "title": {
-      "text": "Magic Stick",
+      "text": "The Growing Town",
       "color": "white"
     },
     "description": {
-      "text": "Acquire a Town Wand from the flag's crafting tab"
+      "text": "Complete 20 procedural quest batches"
     },
     "icon": {
-      "item": "questown:town_wand"
+      "item": "questown:town_flag_block"
     },
-    "frame": "goal",
+    "frame": "challenge",
     "show_toast": true,
     "announce_to_chat": true,
     "hidden": false,
@@ -18,9 +18,9 @@
   },
   "criteria": {
     "Trigger": {
-      "trigger": "questown:room_trigger",
+      "trigger": "questown:tutorial_trigger",
       "conditions": {
-        "context": "wand_get"
+        "context": "chapter_4"
       }
     }
   },
@@ -30,7 +30,7 @@
     ]
   ],
   "rewards": {
-    "experience": 100
+    "experience": 500
   },
-  "parent": "questown:first_visitor"
+  "parent": "questown:chapter_3"
 }

--- a/src/main/resources/data/questown/advancements/first_bop_spend.json
+++ b/src/main/resources/data/questown/advancements/first_bop_spend.json
@@ -1,26 +1,26 @@
 {
   "display": {
     "title": {
-      "text": "Magic Stick",
+      "text": "Investor",
       "color": "white"
     },
     "description": {
-      "text": "Acquire a Town Wand from the flag's crafting tab"
+      "text": "Spend your first Block of Progress to unlock a new job"
     },
     "icon": {
-      "item": "questown:town_wand"
+      "item": "minecraft:emerald_block"
     },
     "frame": "goal",
     "show_toast": true,
     "announce_to_chat": true,
-    "hidden": false,
+    "hidden": true,
     "background": "minecraft:textures/gui/advancements/backgrounds/stone.png"
   },
   "criteria": {
     "Trigger": {
-      "trigger": "questown:room_trigger",
+      "trigger": "questown:tutorial_trigger",
       "conditions": {
-        "context": "wand_get"
+        "context": "first_bop_spend"
       }
     }
   },
@@ -32,5 +32,5 @@
   "rewards": {
     "experience": 100
   },
-  "parent": "questown:first_visitor"
+  "parent": "questown:first_bop_view"
 }

--- a/src/main/resources/data/questown/advancements/first_bop_view.json
+++ b/src/main/resources/data/questown/advancements/first_bop_view.json
@@ -1,26 +1,26 @@
 {
   "display": {
     "title": {
-      "text": "Magic Stick",
+      "text": "Blocks of Progress",
       "color": "white"
     },
     "description": {
-      "text": "Acquire a Town Wand from the flag's crafting tab"
+      "text": "View the BOP tab in the flag menu for the first time"
     },
     "icon": {
-      "item": "questown:town_wand"
+      "item": "minecraft:emerald"
     },
     "frame": "goal",
     "show_toast": true,
     "announce_to_chat": true,
-    "hidden": false,
+    "hidden": true,
     "background": "minecraft:textures/gui/advancements/backgrounds/stone.png"
   },
   "criteria": {
     "Trigger": {
-      "trigger": "questown:room_trigger",
+      "trigger": "questown:tutorial_trigger",
       "conditions": {
-        "context": "wand_get"
+        "context": "first_bop_view"
       }
     }
   },
@@ -32,5 +32,5 @@
   "rewards": {
     "experience": 100
   },
-  "parent": "questown:first_visitor"
+  "parent": "questown:first_open_flag_menu"
 }

--- a/src/main/resources/data/questown/advancements/first_campfire_sleep.json
+++ b/src/main/resources/data/questown/advancements/first_campfire_sleep.json
@@ -1,26 +1,26 @@
 {
   "display": {
     "title": {
-      "text": "Magic Stick",
+      "text": "Roughing It",
       "color": "white"
     },
     "description": {
-      "text": "Acquire a Town Wand from the flag's crafting tab"
+      "text": "Sleep by the town campfire"
     },
     "icon": {
-      "item": "questown:town_wand"
+      "item": "minecraft:campfire"
     },
     "frame": "goal",
     "show_toast": true,
     "announce_to_chat": true,
-    "hidden": false,
+    "hidden": true,
     "background": "minecraft:textures/gui/advancements/backgrounds/stone.png"
   },
   "criteria": {
     "Trigger": {
-      "trigger": "questown:room_trigger",
+      "trigger": "questown:tutorial_trigger",
       "conditions": {
-        "context": "wand_get"
+        "context": "first_campfire_sleep"
       }
     }
   },
@@ -30,7 +30,7 @@
     ]
   ],
   "rewards": {
-    "experience": 100
+    "experience": 50
   },
-  "parent": "questown:first_visitor"
+  "parent": "questown:root"
 }

--- a/src/main/resources/data/questown/advancements/first_job_block.json
+++ b/src/main/resources/data/questown/advancements/first_job_block.json
@@ -1,11 +1,11 @@
 {
   "display": {
     "title": {
-      "text": "TO-DO",
+      "text": "Open for Business",
       "color": "white"
     },
     "description": {
-      "text": "Place a block which a villager can use to do work"
+      "text": "Place a work block that a villager can use"
     },
     "icon": {
       "item": "crafting_table"

--- a/src/main/resources/data/questown/advancements/first_room_upgrade.json
+++ b/src/main/resources/data/questown/advancements/first_room_upgrade.json
@@ -1,26 +1,26 @@
 {
   "display": {
     "title": {
-      "text": "Magic Stick",
+      "text": "Room Upgrade",
       "color": "white"
     },
     "description": {
-      "text": "Acquire a Town Wand from the flag's crafting tab"
+      "text": "Upgrade a room by adding more blocks to it"
     },
     "icon": {
-      "item": "questown:town_wand"
+      "item": "minecraft:chest"
     },
     "frame": "goal",
     "show_toast": true,
     "announce_to_chat": true,
-    "hidden": false,
+    "hidden": true,
     "background": "minecraft:textures/gui/advancements/backgrounds/stone.png"
   },
   "criteria": {
     "Trigger": {
-      "trigger": "questown:room_trigger",
+      "trigger": "questown:tutorial_trigger",
       "conditions": {
-        "context": "wand_get"
+        "context": "first_room_upgrade"
       }
     }
   },
@@ -32,5 +32,5 @@
   "rewards": {
     "experience": 100
   },
-  "parent": "questown:first_visitor"
+  "parent": "questown:first_store_room"
 }

--- a/src/main/resources/data/questown/advancements/first_unmet_needs.json
+++ b/src/main/resources/data/questown/advancements/first_unmet_needs.json
@@ -11,9 +11,9 @@
       "item": "minecraft:bone"
     },
     "frame": "goal",
-    "show_toast": false,
-    "announce_to_chat": false,
-    "hidden": true,
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false,
     "background": "minecraft:textures/gui/advancements/backgrounds/stone.png"
   },
   "criteria": {

--- a/src/main/resources/data/questown/advancements/first_warp.json
+++ b/src/main/resources/data/questown/advancements/first_warp.json
@@ -1,26 +1,26 @@
 {
   "display": {
     "title": {
-      "text": "Magic Stick",
+      "text": "While You Were Away",
       "color": "white"
     },
     "description": {
-      "text": "Acquire a Town Wand from the flag's crafting tab"
+      "text": "Leave town for at least one day and return to see what your villagers produced"
     },
     "icon": {
-      "item": "questown:town_wand"
+      "item": "minecraft:compass"
     },
     "frame": "goal",
     "show_toast": true,
     "announce_to_chat": true,
-    "hidden": false,
+    "hidden": true,
     "background": "minecraft:textures/gui/advancements/backgrounds/stone.png"
   },
   "criteria": {
     "Trigger": {
-      "trigger": "questown:room_trigger",
+      "trigger": "questown:tutorial_trigger",
       "conditions": {
-        "context": "wand_get"
+        "context": "first_warp"
       }
     }
   },
@@ -32,5 +32,5 @@
   "rewards": {
     "experience": 100
   },
-  "parent": "questown:first_visitor"
+  "parent": "questown:second_job_type"
 }

--- a/src/main/resources/data/questown/advancements/second_job_type.json
+++ b/src/main/resources/data/questown/advancements/second_job_type.json
@@ -1,26 +1,26 @@
 {
   "display": {
     "title": {
-      "text": "Magic Stick",
+      "text": "Supply Chain",
       "color": "white"
     },
     "description": {
-      "text": "Acquire a Town Wand from the flag's crafting tab"
+      "text": "Have multiple job types working simultaneously"
     },
     "icon": {
-      "item": "questown:town_wand"
+      "item": "minecraft:bread"
     },
     "frame": "goal",
     "show_toast": true,
     "announce_to_chat": true,
-    "hidden": false,
+    "hidden": true,
     "background": "minecraft:textures/gui/advancements/backgrounds/stone.png"
   },
   "criteria": {
     "Trigger": {
-      "trigger": "questown:room_trigger",
+      "trigger": "questown:tutorial_trigger",
       "conditions": {
-        "context": "wand_get"
+        "context": "second_job_type"
       }
     }
   },
@@ -32,5 +32,5 @@
   "rewards": {
     "experience": 100
   },
-  "parent": "questown:first_visitor"
+  "parent": "questown:tutorial_complete"
 }

--- a/src/main/resources/data/questown/advancements/tutorial_complete.json
+++ b/src/main/resources/data/questown/advancements/tutorial_complete.json
@@ -1,26 +1,26 @@
 {
   "display": {
     "title": {
-      "text": "Magic Stick",
+      "text": "Tutorial Complete",
       "color": "white"
     },
     "description": {
-      "text": "Acquire a Town Wand from the flag's crafting tab"
+      "text": "Complete all tutorial quests and unlock the crafter"
     },
     "icon": {
-      "item": "questown:town_wand"
+      "item": "minecraft:writable_book"
     },
     "frame": "goal",
     "show_toast": true,
     "announce_to_chat": true,
-    "hidden": false,
+    "hidden": true,
     "background": "minecraft:textures/gui/advancements/backgrounds/stone.png"
   },
   "criteria": {
     "Trigger": {
-      "trigger": "questown:room_trigger",
+      "trigger": "questown:tutorial_trigger",
       "conditions": {
-        "context": "wand_get"
+        "context": "tutorial_complete"
       }
     }
   },
@@ -32,5 +32,5 @@
   "rewards": {
     "experience": 100
   },
-  "parent": "questown:first_visitor"
+  "parent": "questown:first_job_done"
 }

--- a/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/012-skill-tree.json
+++ b/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/012-skill-tree.json
@@ -1,0 +1,13 @@
+{
+  "sortnum": 12,
+  "name": "12: The Skill Tree",
+  "icon": "minecraft:writable_book",
+  "category": "questown:entries",
+  "advancement": "questown:job_quest",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "Each villager has a skill tree. Open their menu and check the Skills tab.$(br2)Locked jobs need a Block of Progress to unlock. Your villagers earn these as they work -- check the flag menu's BOP tab."
+    }
+  ]
+}

--- a/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/013-the-crafter.json
+++ b/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/013-the-crafter.json
@@ -1,0 +1,13 @@
+{
+  "sortnum": 13,
+  "name": "13: The Crafter",
+  "icon": "minecraft:writable_book",
+  "category": "questown:entries",
+  "advancement": "questown:tutorial_complete",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "You can craft bowls, shears, and fishing rods yourself at a crafting table. But your crafter does it for you at scale -- freeing you to explore while your village keeps producing.$(br2)More importantly, the crafter makes things you CAN'T: fishing stations are only obtainable from a crafter villager. Prioritize unlocking crafter jobs on the skill tree."
+    }
+  ]
+}

--- a/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/014-supply-chains.json
+++ b/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/014-supply-chains.json
@@ -1,0 +1,13 @@
+{
+  "sortnum": 14,
+  "name": "14: Supply Chains",
+  "icon": "minecraft:writable_book",
+  "category": "questown:entries",
+  "advancement": "questown:second_job_type",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "Your villagers feed each other's work. Try this: set up a farmer, then unlock and build a baker. Watch the baker turn your farmer's wheat into bread automatically.$(br2)The store room is the hub -- everyone deposits and picks up from there. If someone is idle, check whether their supplier is keeping up."
+    }
+  ]
+}

--- a/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/015-while-you-were-away.json
+++ b/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/015-while-you-were-away.json
@@ -1,0 +1,13 @@
+{
+  "sortnum": 15,
+  "name": "15: While You Were Away",
+  "icon": "minecraft:writable_book",
+  "category": "questown:entries",
+  "advancement": "questown:first_warp",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "Your village ran itself while you were gone. Travel far away, explore, adventure. When you come back, check the store room -- your villagers kept producing.$(br2)Make sure they have supplies and storage before you leave."
+    }
+  ]
+}

--- a/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/lesson_bop.json
+++ b/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/lesson_bop.json
@@ -1,0 +1,13 @@
+{
+  "sortnum": 7,
+  "name": "Blocks of Progress",
+  "icon": "minecraft:book",
+  "category": "questown:lessons",
+  "advancement": "questown:job_quest",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "You spent a BOP to unlock a new job. As your villagers work, they'll earn more. Use them to branch deeper into each skill tree.$(br2)Choose wisely early on -- they're scarce at first."
+    }
+  ]
+}

--- a/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/lesson_campfire_sleep.json
+++ b/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/lesson_campfire_sleep.json
@@ -1,0 +1,13 @@
+{
+  "sortnum": 12,
+  "name": "Roughing It",
+  "icon": "minecraft:campfire",
+  "category": "questown:lessons",
+  "advancement": "questown:first_campfire_sleep",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "Hold your Town Wand and right-click the campfire at night to sleep there.$(br2)You won't set a spawn point. You'll wake up groggy: Mining Fatigue and Weakness for a few minutes.$(br2)Drink milk to clear the effects early."
+    }
+  ]
+}

--- a/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/lesson_crafter.json
+++ b/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/lesson_crafter.json
@@ -1,0 +1,17 @@
+{
+  "sortnum": 8,
+  "name": "The Crafter's Workshop",
+  "icon": "minecraft:book",
+  "category": "questown:lessons",
+  "advancement": "questown:tutorial_complete",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "The crafter automates crafting at scale. Bowls, shears, fishing rods, ladders, paper -- your crafter makes them so you don't have to.$(br2)And some items are crafter-exclusive: fishing stations can ONLY be made by a crafter villager."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "The crafter skill tree branches from sticks into specialized tools. Unlock fishing_rod before you can unlock fishing_station."
+    }
+  ]
+}

--- a/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/lesson_flag.json
+++ b/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/lesson_flag.json
@@ -1,0 +1,13 @@
+{
+  "sortnum": 6,
+  "name": "The Flag",
+  "icon": "minecraft:book",
+  "category": "questown:lessons",
+  "advancement": "questown:first_open_flag_menu",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "Right-click the flag to open the town menu. From here you can see your villagers, quests, economics, and BOP tabs.$(br2)The flag also converts items: hold a stick and right-click to get a town wand, or hold a pressure plate to get a welcome mat."
+    }
+  ]
+}

--- a/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/lesson_needs.json
+++ b/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/lesson_needs.json
@@ -2,7 +2,7 @@
   "sortnum": 11,
   "name": "Villager Needs",
   "icon": "minecraft:writable_book",
-  "category": "questown:entries",
+  "category": "questown:lessons",
   "advancement": "questown:first_unmet_needs",
   "pages": [
     {

--- a/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/lesson_room_recipes.json
+++ b/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/lesson_room_recipes.json
@@ -1,0 +1,13 @@
+{
+  "sortnum": 3,
+  "name": "Room Recipes",
+  "icon": "minecraft:book",
+  "category": "questown:lessons",
+  "advancement": "questown:first_job_done",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "What you put inside a room defines its purpose. Furnace = kitchen. Crafting table = crafting room.$(br2)Quests tell you what to build -- but you can experiment by adding blocks to see what a room becomes."
+    }
+  ]
+}

--- a/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/lesson_storage.json
+++ b/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/lesson_storage.json
@@ -1,0 +1,17 @@
+{
+  "sortnum": 4,
+  "name": "Storage Tiers",
+  "icon": "minecraft:book",
+  "category": "questown:lessons",
+  "advancement": "questown:first_store_room",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "When storage fills up, production stops. Upgrade before you need it.$(br2)Villagers can't stack items. Each item takes one slot. This means storage fills up faster than you'd expect -- plan for more chests than you think you need."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Storage progression: start with one chest, then add more to upgrade your store room to a warehouse. Don't demolish -- just add."
+    }
+  ]
+}

--- a/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/lesson_upgrades.json
+++ b/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/lesson_upgrades.json
@@ -1,0 +1,13 @@
+{
+  "sortnum": 9,
+  "name": "Room Upgrades",
+  "icon": "minecraft:book",
+  "category": "questown:lessons",
+  "advancement": "questown:first_room_upgrade",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "Add blocks to upgrade rooms. Don't demolish -- just add. Quests tell you what to build next."
+    }
+  ]
+}

--- a/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/lesson_wand.json
+++ b/src/main/resources/data/questown/patchouli_books/intro/en_us/entries/lesson_wand.json
@@ -1,0 +1,13 @@
+{
+  "sortnum": 5,
+  "name": "The Town Wand",
+  "icon": "minecraft:book",
+  "category": "questown:lessons",
+  "advancement": "questown:wand_get",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "Click a door to register the room with your town. Click a gate to register a farm. Click a special block to register a block room.$(br2)If a villager isn't using a room, you probably forgot to register it."
+    }
+  ]
+}

--- a/src/test/java/ca/bradj/questown/core/advancements/TutorialTriggerTest.java
+++ b/src/test/java/ca/bradj/questown/core/advancements/TutorialTriggerTest.java
@@ -1,0 +1,68 @@
+package ca.bradj.questown.core.advancements;
+
+import com.google.gson.JsonPrimitive;
+import net.minecraft.advancements.critereon.EntityPredicate;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TutorialTriggerTest {
+
+    @Test
+    void allTriggersExceptInvalidHaveStringIds() {
+        for (TutorialTrigger.Triggers trigger : TutorialTrigger.Triggers.values()) {
+            if (trigger == TutorialTrigger.Triggers.Invalid) {
+                continue;
+            }
+            assertNotNull(trigger.getID(), "Trigger " + trigger + " should have a string ID");
+            assertFalse(trigger.getID().isEmpty(), "Trigger " + trigger + " should have a non-empty string ID");
+        }
+    }
+
+    @Test
+    void invalidTriggerHasNoStringId() {
+        assertNull(TutorialTrigger.Triggers.Invalid.getID());
+    }
+
+    @Test
+    void fromJSON_roundTrips() {
+        for (TutorialTrigger.Triggers trigger : TutorialTrigger.Triggers.values()) {
+            if (trigger == TutorialTrigger.Triggers.Invalid) {
+                continue;
+            }
+            String id = trigger.getID();
+            TutorialTrigger.Triggers parsed = TutorialTrigger.Triggers.fromJSON(new JsonPrimitive(id));
+            assertEquals(trigger, parsed, "Round-trip failed for trigger " + trigger);
+        }
+    }
+
+    @Test
+    void fromJSON_unknownIdThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+                TutorialTrigger.Triggers.fromJSON(new JsonPrimitive("bogus"))
+        );
+    }
+
+    @Test
+    void instanceRejectsInvalidContext() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new TutorialTrigger.Instance(EntityPredicate.Composite.ANY, TutorialTrigger.Triggers.Invalid)
+        );
+    }
+
+    @Test
+    void instanceMatchesCorrectTrigger() {
+        TutorialTrigger.Instance instance = new TutorialTrigger.Instance(
+                EntityPredicate.Composite.ANY, TutorialTrigger.Triggers.TutorialComplete
+        );
+        assertTrue(instance.matches(TutorialTrigger.Triggers.TutorialComplete));
+    }
+
+    @Test
+    void instanceDoesNotMatchDifferentTrigger() {
+        TutorialTrigger.Instance instance = new TutorialTrigger.Instance(
+                EntityPredicate.Composite.ANY, TutorialTrigger.Triggers.TutorialComplete
+        );
+        assertFalse(instance.matches(TutorialTrigger.Triggers.SecondJobType));
+    }
+}

--- a/src/test/java/ca/bradj/questown/town/entity/ExoticWoodSelectionTest.java
+++ b/src/test/java/ca/bradj/questown/town/entity/ExoticWoodSelectionTest.java
@@ -1,0 +1,121 @@
+package ca.bradj.questown.town.entity;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExoticWoodSelectionTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    private static ResourceLocation oakLog() {
+        return new ResourceLocation("minecraft", "oak_log");
+    }
+
+    private static ResourceLocation birchLog() {
+        return new ResourceLocation("minecraft", "birch_log");
+    }
+
+    private static ResourceLocation spruceLog() {
+        return new ResourceLocation("minecraft", "spruce_log");
+    }
+
+    private static ResourceLocation jungleLog() {
+        return new ResourceLocation("minecraft", "jungle_log");
+    }
+
+    private static ResourceLocation acaciaLog() {
+        return new ResourceLocation("minecraft", "acacia_log");
+    }
+
+    private static ResourceLocation darkOakLog() {
+        return new ResourceLocation("minecraft", "dark_oak_log");
+    }
+
+    @Test
+    void forestBiomeGetsForeignWood() {
+        ResourceLocation result = TownFlagTutorialAdapter.chooseExoticWood("forest");
+        assertNotEquals(oakLog(), result);
+        assertNotNull(result);
+    }
+
+    @Test
+    void birchForestGetsForeignWood() {
+        ResourceLocation result = TownFlagTutorialAdapter.chooseExoticWood("birch_forest");
+        // "birch_forest" contains both "birch" and "forest" substrings;
+        // the result should not be both oak AND birch (it must exclude at least one native)
+        boolean excludesBirch = !birchLog().equals(result);
+        boolean excludesOak = !oakLog().equals(result);
+        assertTrue(excludesBirch || excludesOak,
+                "Expected exotic wood to exclude at least one native wood type for birch_forest");
+        assertNotNull(result);
+    }
+
+    @Test
+    void taigaGetsForeignWood() {
+        ResourceLocation result = TownFlagTutorialAdapter.chooseExoticWood("taiga");
+        assertNotEquals(spruceLog(), result);
+        assertNotNull(result);
+    }
+
+    @Test
+    void jungleGetsForeignWood() {
+        ResourceLocation result = TownFlagTutorialAdapter.chooseExoticWood("jungle");
+        assertNotEquals(jungleLog(), result);
+        assertNotNull(result);
+    }
+
+    @Test
+    void savannaGetsForeignWood() {
+        ResourceLocation result = TownFlagTutorialAdapter.chooseExoticWood("savanna");
+        assertNotEquals(acaciaLog(), result);
+        assertNotNull(result);
+    }
+
+    @Test
+    void darkForestGetsForeignWood() {
+        ResourceLocation result = TownFlagTutorialAdapter.chooseExoticWood("dark_forest");
+        assertNotEquals(darkOakLog(), result);
+        assertNotNull(result);
+    }
+
+    @Test
+    void mangroveSwampGetsForeignWood() {
+        ResourceLocation result = TownFlagTutorialAdapter.chooseExoticWood("mangrove_swamp");
+        ResourceLocation mangroveLog = new ResourceLocation("minecraft", "mangrove_log");
+        assertNotEquals(mangroveLog, result);
+        assertNotNull(result);
+    }
+
+    @Test
+    void plainsBiomeGetsFirstAvailableWood() {
+        ResourceLocation result = TownFlagTutorialAdapter.chooseExoticWood("plains");
+        assertEquals(oakLog(), result);
+    }
+
+    @Test
+    void unknownBiomeGetsFirstAvailableWood() {
+        ResourceLocation result = TownFlagTutorialAdapter.chooseExoticWood("mushroom_fields");
+        assertEquals(oakLog(), result);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "forest", "birch_forest", "taiga", "jungle",
+            "savanna", "dark_forest", "mangrove_swamp",
+            "plains", "mushroom_fields", "desert", "swamp"
+    })
+    void resultIsNeverNull(String biome) {
+        assertNotNull(TownFlagTutorialAdapter.chooseExoticWood(biome));
+    }
+}

--- a/src/test/java/ca/bradj/questown/town/entity/NoOpReward.java
+++ b/src/test/java/ca/bradj/questown/town/entity/NoOpReward.java
@@ -1,0 +1,49 @@
+package ca.bradj.questown.town.entity;
+
+import ca.bradj.questown.town.interfaces.TownInterface;
+import ca.bradj.questown.town.quests.MCReward;
+import ca.bradj.questown.town.rewards.RewardType;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.NotNull;
+
+class NoOpReward extends MCReward {
+
+    static final RewardType<NoOpReward> TYPE = new RewardType<>(
+            (rType, entity) -> new NoOpReward(),
+            new ResourceLocation("questown", "test_noop")
+    );
+
+    NoOpReward() {
+        super(TYPE);
+    }
+
+    @Override
+    protected @NotNull RewardApplier getApplier() {
+        return () -> {};
+    }
+
+    @Override
+    public boolean addsQuestsWhenApplied() {
+        return false;
+    }
+
+    @Override
+    protected CompoundTag serializeNbt() {
+        return new CompoundTag();
+    }
+
+    @Override
+    protected void deserializeNbt(TownInterface entity, CompoundTag tag) {
+    }
+
+    @Override
+    public String toNiceString() {
+        return "NoOp";
+    }
+
+    @Override
+    public boolean contains(@NotNull RewardType<?> reward) {
+        return false;
+    }
+}

--- a/src/test/java/ca/bradj/questown/town/entity/TestTutorialTownView.java
+++ b/src/test/java/ca/bradj/questown/town/entity/TestTutorialTownView.java
@@ -1,0 +1,147 @@
+package ca.bradj.questown.town.entity;
+
+import ca.bradj.questown.core.advancements.TutorialTrigger;
+import ca.bradj.questown.jobs.JobID;
+import ca.bradj.questown.town.quests.MCQuestBatches;
+import ca.bradj.questown.town.quests.MCReward;
+import net.minecraft.resources.ResourceLocation;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+class TestTutorialTownView implements TutorialTownView {
+
+    private int villagerCount;
+    private boolean tutorialBopGranted;
+    private int bopGranted;
+    private final List<String> messagesSent = new ArrayList<>();
+    private final List<TutorialTrigger.Triggers> triggersFired = new ArrayList<>();
+    private final List<String> rewardPhaseNames = new ArrayList<>();
+    private ResourceLocation exoticWood;
+    private JobID jobForTutorial;
+    private ResourceLocation roomForJob;
+
+    private TestTutorialTownView() {
+    }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public int villagerCount() {
+        return villagerCount;
+    }
+
+    @Override
+    public boolean tutorialBopGranted() {
+        return tutorialBopGranted;
+    }
+
+    @Override
+    public void grantBop(int amount) {
+        bopGranted += amount;
+    }
+
+    @Override
+    public void markTutorialBopGranted() {
+        tutorialBopGranted = true;
+    }
+
+    @Override
+    public void broadcastMessage(String message) {
+        messagesSent.add(message);
+    }
+
+    @Override
+    public void broadcastTutorialToast(String titleKey, String descriptionKey) {
+        messagesSent.add(titleKey + ":" + descriptionKey);
+    }
+
+    @Override
+    public void fireTutorialTrigger(TutorialTrigger.Triggers trigger) {
+        triggersFired.add(trigger);
+    }
+
+    @Override
+    public ResourceLocation getExoticWood() {
+        return exoticWood;
+    }
+
+    @Override
+    @Nullable
+    public JobID chooseJobForTutorial(MCQuestBatches questBatches) {
+        return jobForTutorial;
+    }
+
+    @Override
+    public ResourceLocation getRoomForJob(JobID job) {
+        return roomForJob;
+    }
+
+    @Override
+    public MCReward makeReward(String phaseName) {
+        rewardPhaseNames.add(phaseName);
+        return new NoOpReward();
+    }
+
+    List<String> getMessagesSent() {
+        return messagesSent;
+    }
+
+    List<TutorialTrigger.Triggers> getTriggersFired() {
+        return triggersFired;
+    }
+
+    int getBopGranted() {
+        return bopGranted;
+    }
+
+    List<String> getRewardPhaseNames() {
+        return rewardPhaseNames;
+    }
+
+    static class Builder {
+        private int villagerCount = 1;
+        private boolean tutorialBopGranted = false;
+        private ResourceLocation exoticWood = new ResourceLocation("minecraft", "dark_oak_log");
+        private JobID jobForTutorial = new JobID("farmer", "wheat");
+        private ResourceLocation roomForJob = new ResourceLocation("questown", "farm");
+
+        Builder villagerCount(int count) {
+            this.villagerCount = count;
+            return this;
+        }
+
+        Builder tutorialBopGranted(boolean granted) {
+            this.tutorialBopGranted = granted;
+            return this;
+        }
+
+        Builder exoticWood(ResourceLocation wood) {
+            this.exoticWood = wood;
+            return this;
+        }
+
+        Builder jobForTutorial(JobID job) {
+            this.jobForTutorial = job;
+            return this;
+        }
+
+        Builder roomForJob(ResourceLocation room) {
+            this.roomForJob = room;
+            return this;
+        }
+
+        TestTutorialTownView build() {
+            TestTutorialTownView view = new TestTutorialTownView();
+            view.villagerCount = villagerCount;
+            view.tutorialBopGranted = tutorialBopGranted;
+            view.exoticWood = exoticWood;
+            view.jobForTutorial = jobForTutorial;
+            view.roomForJob = roomForJob;
+            return view;
+        }
+    }
+}

--- a/src/test/java/ca/bradj/questown/town/entity/TutorialPhaseGateTest.java
+++ b/src/test/java/ca/bradj/questown/town/entity/TutorialPhaseGateTest.java
@@ -1,0 +1,573 @@
+package ca.bradj.questown.town.entity;
+
+import ca.bradj.questown.core.advancements.TutorialTrigger;
+import ca.bradj.questown.jobs.JobID;
+import ca.bradj.questown.mc.Compat;
+import ca.bradj.questown.town.quests.MCQuest;
+import ca.bradj.questown.town.quests.MCQuestBatch;
+import ca.bradj.questown.town.quests.Quest;
+import ca.bradj.questown.town.quests.QuestBatch;
+import ca.bradj.questown.town.special.SpecialQuests;
+import net.minecraft.SharedConstants;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.item.Items;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TutorialPhaseGateTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    private static final QuestBatch.ChangeListener<MCQuest> NO_OP_LISTENER = new QuestBatch.ChangeListener<>() {
+        @Override
+        public void questCompleted(MCQuest quest) {}
+
+        @Override
+        public void questBatchCompleted(QuestBatch<?, ?, ?, ?> quest) {}
+
+        @Override
+        public void questLost(MCQuest quest) {}
+    };
+
+    private TownQuests newTownQuests() {
+        TownQuests quests = new TownQuests();
+        quests.questBatches.addChangeListener(NO_OP_LISTENER);
+        return quests;
+    }
+
+    private TownQuests questsWithCampfireOnly() {
+        TownQuests quests = newTownQuests();
+        MCQuestBatch batch = new MCQuestBatch(null, null, new NoOpReward());
+        batch.addNewQuest(null, SpecialQuests.CAMPFIRE);
+        quests.questBatches.add(batch);
+        return quests;
+    }
+
+    private TownQuests questsWithCampfireDone() {
+        TownQuests quests = newTownQuests();
+        MCQuestBatch batch = new MCQuestBatch(null, null, new NoOpReward());
+        batch.addNewQuest(null, SpecialQuests.CAMPFIRE);
+        batch.markRecipeAsComplete(null, SpecialQuests.CAMPFIRE);
+        quests.questBatches.add(batch);
+        return quests;
+    }
+
+    private void addKickoffQuests(TownQuests quests) {
+        TestTutorialTownView view = TestTutorialTownView.builder().build();
+        quests.addTutorialBatches(view);
+    }
+
+    private void completeAllKickoffQuests(TownQuests quests) {
+        quests.questBatches.markRecipeAsComplete(null, SpecialQuests.TOWN_GATE);
+        quests.questBatches.markRecipeAsComplete(null, SpecialQuests.JOB_BOARD);
+        quests.questBatches.markRecipeAsComplete(null, SpecialQuests.STORE_ROOM_SMALL);
+        quests.questBatches.markRecipeAsComplete(null, Compat.getItemId(Items.WOODEN_SWORD));
+    }
+
+    // ===== Phase 1: Campfire → Kickoff =====
+
+    @Test
+    void whenOnlyCampfireQuest_kickoffQuestsAdded() {
+        TownQuests quests = questsWithCampfireOnly();
+        TestTutorialTownView view = TestTutorialTownView.builder().build();
+
+        TownQuests.Tutorial result = quests.addTutorialBatches(view);
+
+        assertEquals(TownQuests.Tutorial.APPLIED, result);
+        List<MCQuest> all = quests.questBatches.getAll();
+        assertTrue(all.stream().anyMatch(q -> SpecialQuests.TOWN_GATE.equals(q.getWantedId())));
+        assertTrue(all.stream().anyMatch(q -> SpecialQuests.JOB_BOARD.equals(q.getWantedId())));
+        assertTrue(all.stream().anyMatch(q -> SpecialQuests.STORE_ROOM_SMALL.equals(q.getWantedId())));
+        assertTrue(all.stream().anyMatch(q ->
+                Compat.getItemId(Items.WOODEN_SWORD).equals(q.getWantedId())
+                && q.getType() == Quest.QuestType.ITEM
+        ));
+    }
+
+    @Test
+    void whenCampfireNotDone_noAdvance() {
+        TownQuests quests = questsWithCampfireOnly();
+        TestTutorialTownView view = TestTutorialTownView.builder().build();
+
+        // First call adds kickoff quests from campfire
+        quests.addTutorialBatches(view);
+
+        // Campfire quest is still there but kickoff quests are not all done
+        // The method should skip on subsequent call since batches > 1 and kickoff not done
+        TownQuests.Tutorial result = quests.addTutorialBatches(view);
+        assertEquals(TownQuests.Tutorial.SKIPPED, result);
+    }
+
+    // ===== Phase 2: Kickoff → Hunter-Gatherer =====
+
+    @Test
+    void whenKickoffDoneAndTwoVillagers_hunterGathererAdded() {
+        TownQuests quests = questsWithCampfireDone();
+        addKickoffQuests(quests);
+        completeAllKickoffQuests(quests);
+
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(2)
+                .build();
+
+        TownQuests.Tutorial result = quests.addTutorialBatches(view);
+
+        assertEquals(TownQuests.Tutorial.APPLIED, result);
+        List<MCQuest> all = quests.questBatches.getAll();
+        assertTrue(all.stream().anyMatch(q ->
+                Compat.getItemId(Items.MUTTON).equals(q.getWantedId())
+        ));
+        assertTrue(all.stream().anyMatch(q ->
+                Compat.getItemId(Items.STONE_SWORD).equals(q.getWantedId())
+        ));
+        assertTrue(all.stream().anyMatch(q ->
+                q.getType() == Quest.QuestType.JOB_CHANGE
+                && q.getWantedId().equals(JobID.toRL(new JobID("hunter", "sword")))
+        ));
+        assertTrue(all.stream().anyMatch(q ->
+                SpecialQuests.BEDROOM.equals(q.getWantedId())
+        ));
+    }
+
+    @Test
+    void whenKickoffDoneAndTwoVillagers_bopGranted() {
+        TownQuests quests = questsWithCampfireDone();
+        addKickoffQuests(quests);
+        completeAllKickoffQuests(quests);
+
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(2)
+                .build();
+
+        quests.addTutorialBatches(view);
+
+        assertEquals(3, view.getBopGranted());
+        assertTrue(view.tutorialBopGranted());
+    }
+
+    @Test
+    void whenKickoffDoneButOneVillager_noAdvance() {
+        TownQuests quests = questsWithCampfireDone();
+        addKickoffQuests(quests);
+        completeAllKickoffQuests(quests);
+
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(1)
+                .build();
+
+        TownQuests.Tutorial result = quests.addTutorialBatches(view);
+        assertEquals(TownQuests.Tutorial.SKIPPED, result);
+    }
+
+    @Test
+    void whenKickoffPartiallyDone_noAdvance() {
+        TownQuests quests = questsWithCampfireDone();
+        addKickoffQuests(quests);
+        // Only complete some kickoff quests
+        quests.questBatches.markRecipeAsComplete(null, SpecialQuests.TOWN_GATE);
+
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(2)
+                .build();
+
+        TownQuests.Tutorial result = quests.addTutorialBatches(view);
+        assertEquals(TownQuests.Tutorial.SKIPPED, result);
+    }
+
+    // ===== Phase 2.5: Hunter → Job Change + Food =====
+
+    private TownQuests questsAtPhase2_5() {
+        TownQuests quests = questsWithCampfireDone();
+        addKickoffQuests(quests);
+        completeAllKickoffQuests(quests);
+
+        // Add hunter-gatherer quests
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(2)
+                .build();
+        quests.addTutorialBatches(view);
+
+        // Complete the hunter job change quest to have one JOB_CHANGE
+        ResourceLocation hunterJob = JobID.toRL(new JobID("hunter", "sword"));
+        quests.questBatches.markRecipeAsComplete(null, hunterJob);
+        quests.questBatches.markRecipeAsComplete(null, Compat.getItemId(Items.MUTTON));
+        quests.questBatches.markRecipeAsComplete(null, Compat.getItemId(Items.STONE_SWORD));
+        quests.questBatches.markRecipeAsComplete(null, SpecialQuests.BEDROOM);
+
+        return quests;
+    }
+
+    @Test
+    void whenHunterDoneAndThreeVillagers_jobChangeAndFoodAdded() {
+        TownQuests quests = questsAtPhase2_5();
+
+        JobID farmerJob = new JobID("farmer", "wheat");
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(3)
+                .jobForTutorial(farmerJob)
+                .build();
+
+        TownQuests.Tutorial result = quests.addTutorialBatches(view);
+
+        assertEquals(TownQuests.Tutorial.APPLIED, result);
+        List<MCQuest> all = quests.questBatches.getAll();
+        assertTrue(all.stream().anyMatch(q ->
+                Compat.getItemId(Items.APPLE).equals(q.getWantedId())
+                && q.getType() == Quest.QuestType.ITEM
+        ));
+        assertTrue(all.stream().anyMatch(q ->
+                q.getType() == Quest.QuestType.JOB_CHANGE
+                && q.getWantedId().equals(JobID.toRL(farmerJob))
+        ));
+    }
+
+    @Test
+    void whenHunterDoneButTwoVillagers_noAdvance() {
+        TownQuests quests = questsAtPhase2_5();
+
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(2)
+                .build();
+
+        TownQuests.Tutorial result = quests.addTutorialBatches(view);
+        assertEquals(TownQuests.Tutorial.SKIPPED, result);
+    }
+
+    // ===== Phase 2.5 → Phase 4 (Phase 3 is skipped when tutorial quests have null owners) =====
+
+    private TownQuests questsWithTwoJobChangesDone() {
+        TownQuests quests = questsAtPhase2_5();
+
+        JobID farmerJob = new JobID("farmer", "wheat");
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(3)
+                .jobForTutorial(farmerJob)
+                .build();
+        quests.addTutorialBatches(view);
+
+        // Complete the second job change and apple quest
+        quests.questBatches.markRecipeAsComplete(null, JobID.toRL(farmerJob));
+        quests.questBatches.markRecipeAsComplete(null, Compat.getItemId(Items.APPLE));
+
+        return quests;
+    }
+
+    @Test
+    void whenTwoJobChangesDone_crafterQuestsAdded_tutorialCompleteTriggerFired() {
+        TownQuests quests = questsWithTwoJobChangesDone();
+
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(3)
+                .build();
+
+        TownQuests.Tutorial result = quests.addTutorialBatches(view);
+
+        assertEquals(TownQuests.Tutorial.APPLIED, result);
+        List<MCQuest> all = quests.questBatches.getAll();
+        ResourceLocation crafterStick = JobID.toRL(new JobID("crafter", "stick"));
+        ResourceLocation crafterBowl = JobID.toRL(new JobID("crafter", "bowl"));
+        ResourceLocation craftingRoom = new ResourceLocation("questown", "crafting_room");
+
+        assertTrue(all.stream().anyMatch(q ->
+                crafterStick.equals(q.getWantedId()) && q.getType() == Quest.QuestType.JOB_CHANGE
+        ));
+        assertTrue(all.stream().anyMatch(q ->
+                craftingRoom.equals(q.getWantedId()) && q.getType() == Quest.QuestType.ROOM
+        ));
+        assertTrue(all.stream().anyMatch(q ->
+                crafterBowl.equals(q.getWantedId()) && q.getType() == Quest.QuestType.JOB_CHANGE
+        ));
+        assertTrue(view.getTriggersFired().contains(TutorialTrigger.Triggers.TutorialComplete));
+    }
+
+    @Test
+    void whenOneJobChangeDone_noAdvance() {
+        TownQuests quests = questsAtPhase2_5();
+
+        // Only the hunter job change is done, second one not added yet
+        // But we need 3 villagers for it to proceed past the villager check
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(3)
+                .jobForTutorial(new JobID("farmer", "wheat"))
+                .build();
+
+        // This should add the second job change quest (phase 2.5), not advance to phase 4
+        TownQuests.Tutorial result = quests.addTutorialBatches(view);
+        assertEquals(TownQuests.Tutorial.APPLIED, result);
+        // The count of JOB_CHANGE quests should be 2 now (hunter + farmer)
+        long jobChangeCount = quests.questBatches.getAll().stream()
+                .filter(q -> q.getType() == Quest.QuestType.JOB_CHANGE)
+                .count();
+        assertEquals(2, jobChangeCount);
+    }
+
+    @Test
+    void whenTwoJobChangesDoneButNotComplete_noAdvance() {
+        TownQuests quests = questsAtPhase2_5();
+
+        JobID farmerJob = new JobID("farmer", "wheat");
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(3)
+                .jobForTutorial(farmerJob)
+                .build();
+        quests.addTutorialBatches(view);
+
+        // Don't complete second job change
+        TownQuests.Tutorial result = quests.addTutorialBatches(view);
+        assertEquals(TownQuests.Tutorial.SKIPPED, result);
+    }
+
+    // ===== Phase 5: Crafter Bowl → Supply Chain =====
+
+    private TownQuests questsWithCrafterDone() {
+        TownQuests quests = questsWithTwoJobChangesDone();
+
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(3)
+                .build();
+        quests.addTutorialBatches(view);
+
+        // Complete crafter quests
+        ResourceLocation crafterStick = JobID.toRL(new JobID("crafter", "stick"));
+        ResourceLocation crafterBowl = JobID.toRL(new JobID("crafter", "bowl"));
+        ResourceLocation craftingRoom = new ResourceLocation("questown", "crafting_room");
+        quests.questBatches.markRecipeAsComplete(null, crafterStick);
+        quests.questBatches.markRecipeAsComplete(null, craftingRoom);
+        quests.questBatches.markRecipeAsComplete(null, crafterBowl);
+
+        return quests;
+    }
+
+    @Test
+    void whenBowlJobDone_supplyChainAdded() {
+        TownQuests quests = questsWithCrafterDone();
+
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(3)
+                .build();
+
+        TownQuests.Tutorial result = quests.addTutorialBatches(view);
+
+        assertEquals(TownQuests.Tutorial.APPLIED, result);
+        List<MCQuest> all = quests.questBatches.getAll();
+        assertTrue(all.stream().anyMatch(q -> q.getType() == Quest.QuestType.CONCURRENT_JOBS));
+        ResourceLocation kitchenSmall = new ResourceLocation("questown", "kitchen_small");
+        assertTrue(all.stream().anyMatch(q ->
+                kitchenSmall.equals(q.getWantedId()) && q.getType() == Quest.QuestType.ROOM
+        ));
+    }
+
+    @Test
+    void whenBowlJobNotDone_noAdvance() {
+        TownQuests quests = questsWithTwoJobChangesDone();
+
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(3)
+                .build();
+        quests.addTutorialBatches(view);
+
+        // Complete only crafter stick, not bowl
+        ResourceLocation crafterStick = JobID.toRL(new JobID("crafter", "stick"));
+        ResourceLocation craftingRoom = new ResourceLocation("questown", "crafting_room");
+        quests.questBatches.markRecipeAsComplete(null, crafterStick);
+        quests.questBatches.markRecipeAsComplete(null, craftingRoom);
+
+        TownQuests.Tutorial result = quests.addTutorialBatches(view);
+        assertEquals(TownQuests.Tutorial.SKIPPED, result);
+    }
+
+    // ===== Phase 6: Supply Chain → Storage Upgrade =====
+
+    private TownQuests questsAtPhase6() {
+        TownQuests quests = questsWithCrafterDone();
+
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(3)
+                .build();
+        quests.addTutorialBatches(view);
+
+        // Complete supply chain quests
+        ResourceLocation concurrentJobs = new ResourceLocation("questown", "concurrent_jobs");
+        ResourceLocation kitchenSmall = new ResourceLocation("questown", "kitchen_small");
+        quests.questBatches.markRecipeAsComplete(null, concurrentJobs);
+        quests.questBatches.markRecipeAsComplete(null, kitchenSmall);
+
+        return quests;
+    }
+
+    @Test
+    void whenConcurrentJobsDone_storageUpgradeAdded_secondJobTypeTriggerFired() {
+        TownQuests quests = questsAtPhase6();
+
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(3)
+                .build();
+
+        TownQuests.Tutorial result = quests.addTutorialBatches(view);
+
+        assertEquals(TownQuests.Tutorial.APPLIED, result);
+        List<MCQuest> all = quests.questBatches.getAll();
+        ResourceLocation storeRoomMedium = new ResourceLocation("questown", "store_room_medium");
+        assertTrue(all.stream().anyMatch(q ->
+                storeRoomMedium.equals(q.getWantedId()) && q.getType() == Quest.QuestType.ROOM
+        ));
+        assertTrue(view.getTriggersFired().contains(TutorialTrigger.Triggers.SecondJobType));
+    }
+
+    // ===== Phase 7: Storage → Exotic Wood =====
+
+    private TownQuests questsAtPhase7() {
+        TownQuests quests = questsAtPhase6();
+
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(3)
+                .build();
+        quests.addTutorialBatches(view);
+
+        // Complete storage upgrade
+        ResourceLocation storeRoomMedium = new ResourceLocation("questown", "store_room_medium");
+        quests.questBatches.markRecipeAsComplete(null, storeRoomMedium);
+
+        return quests;
+    }
+
+    @Test
+    void whenStorageUpgradeDone_exoticWoodAdded_firstRoomUpgradeTriggerFired() {
+        TownQuests quests = questsAtPhase7();
+
+        ResourceLocation exoticWood = new ResourceLocation("minecraft", "jungle_log");
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(3)
+                .exoticWood(exoticWood)
+                .build();
+
+        TownQuests.Tutorial result = quests.addTutorialBatches(view);
+
+        assertEquals(TownQuests.Tutorial.APPLIED, result);
+        List<MCQuest> all = quests.questBatches.getAll();
+        assertTrue(all.stream().anyMatch(q ->
+                exoticWood.equals(q.getWantedId())
+                && q.getType() == Quest.QuestType.ITEM
+                && q.getFlavorText() != null
+                && q.getFlavorText().contains("flagpole")
+        ));
+        assertTrue(view.getTriggersFired().contains(TutorialTrigger.Triggers.FirstRoomUpgrade));
+    }
+
+    // ===== Completion =====
+
+    @Test
+    void whenAllPhasesDone_returnsDone() {
+        TownQuests quests = questsAtPhase7();
+
+        ResourceLocation exoticWood = new ResourceLocation("minecraft", "jungle_log");
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(3)
+                .exoticWood(exoticWood)
+                .build();
+        quests.addTutorialBatches(view);
+
+        // Complete exotic wood quest
+        quests.questBatches.markRecipeAsComplete(null, exoticWood);
+
+        TownQuests.Tutorial result = quests.addTutorialBatches(view);
+        assertEquals(TownQuests.Tutorial.DONE, result);
+    }
+
+    // ===== Edge cases =====
+
+    @Test
+    void whenEmpty_returnsSkipped() {
+        TownQuests quests = new TownQuests();
+        TestTutorialTownView view = TestTutorialTownView.builder().build();
+
+        TownQuests.Tutorial result = quests.addTutorialBatches(view);
+        assertEquals(TownQuests.Tutorial.SKIPPED, result);
+    }
+
+    @Test
+    void whenBopAlreadyGranted_noDuplicateGrant() {
+        TownQuests quests = questsWithCampfireDone();
+        addKickoffQuests(quests);
+        completeAllKickoffQuests(quests);
+
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(2)
+                .tutorialBopGranted(true)
+                .build();
+
+        quests.addTutorialBatches(view);
+        assertEquals(0, view.getBopGranted());
+    }
+
+    @Test
+    void allPhaseNamesAreFromKnownConstants() {
+        Set<String> knownPhaseNames = Set.of(
+                TutorialTownView.PHASE_KICKOFF,
+                TutorialTownView.PHASE_HUNTER_GATHERER,
+                TutorialTownView.PHASE_JOB_CHANGE_FOOD,
+                TutorialTownView.PHASE_NEW_JOB_ROOM,
+                TutorialTownView.PHASE_4A,
+                TutorialTownView.PHASE_4B,
+                TutorialTownView.PHASE_5,
+                TutorialTownView.PHASE_6,
+                TutorialTownView.PHASE_7
+        );
+
+        // Run through all phases to completion and collect phase names
+        TownQuests quests = questsAtPhase7();
+        ResourceLocation exoticWood = new ResourceLocation("minecraft", "jungle_log");
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(3)
+                .exoticWood(exoticWood)
+                .build();
+        quests.addTutorialBatches(view);
+        quests.questBatches.markRecipeAsComplete(null, exoticWood);
+        quests.addTutorialBatches(view);
+
+        List<String> collectedNames = view.getRewardPhaseNames();
+        assertFalse(collectedNames.isEmpty(), "Should have collected at least one phase name");
+        for (String name : collectedNames) {
+            assertTrue(knownPhaseNames.contains(name),
+                    "Phase name '" + name + "' is not in the known constants set");
+        }
+    }
+
+    @Test
+    void whenNewQuestsAdded_broadcastSent() {
+        TownQuests quests = questsWithCampfireDone();
+        addKickoffQuests(quests);
+        completeAllKickoffQuests(quests);
+
+        TestTutorialTownView view = TestTutorialTownView.builder()
+                .villagerCount(2)
+                .build();
+
+        quests.addTutorialBatches(view);
+
+        assertFalse(view.getMessagesSent().isEmpty());
+        assertTrue(view.getMessagesSent().get(0).contains("New quests"));
+    }
+
+    // ===== Milestone: "Your village is thriving" =====
+
+    @Test
+    void campfireBatch_isNotProceduralBatch() {
+        // Regression: placing a campfire (the very first step) was instantly
+        // broadcasting "your village is thriving" because campfire batch
+        // completion was counted as a procedural batch milestone.
+        MCQuestBatch campfireBatch = new MCQuestBatch(null, null, new NoOpReward());
+        campfireBatch.addNewQuest(null, SpecialQuests.CAMPFIRE);
+        assertFalse(TownQuests.isProceduralBatch(campfireBatch));
+    }
+}


### PR DESCRIPTION
The tutorial was a single monolithic batch of quests. It's now split into 7 phases that teach game mechanics progressively: basic building, combat, job assignment, crafting specialization, supply chains, room upgrades, and biome-specific goals.

Quest progression is decoupled from the town flag entity via the TutorialTownView interface, making it testable without Minecraft. Each phase fires advancement triggers that auto-open the relevant Patchouli journal page, and early procedural batches get auto-generated flavor text to guide new players.